### PR TITLE
Save and load `ExpressionSet`s

### DIFF
--- a/demos/demo_save_load.py
+++ b/demos/demo_save_load.py
@@ -34,9 +34,10 @@ expression_data += load_matab_expression_files(
     flipped_rh_file=Path(sample_data_dir,
                          "ins_loudness-flipped_rh_10242verts_-200-800ms_cuttoff1000_5perms_ttestpval.mat"),
 )
-expression_data.save(to_path=Path("/Users/cai/Desktop/temp.nkg"))
+
+expression_data.save("/Users/cai/Desktop/temp.nkg", overwrite=True)
 expression_data2 = ExpressionSet.load(from_path=Path("/Users/cai/Desktop/temp.nkg"))
 
 print(expression_data == expression_data2)
 
-expression_data2.save(to_path=Path("/Users/cai/Desktop/temp2.nkg"))
+expression_data2.save(to_path=Path("/Users/cai/Desktop/temp2.nkg"), overwrite=True)

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -194,14 +194,30 @@ class ExpressionSet:
         return True
 
     def save(self, to_path: Path | str, overwrite: bool = False):
+
+        # Format versioning of the saved file. Used to (eventually) ensure old saved files can always be loaded.
+        #
+        # - Increment MINOR versions when creating a breaking change, but only when we commit to indefinitely supporting
+        #   the new version.
+        # - Increment MAJOR version when creating a breaking change which makes the format fundamentally incompatible
+        #   with previous versions.
+        #
+        # All distinct versions should be documented.
+        #
+        # This value should be saved into file called /_metadata/format-version.txt within an archive.
+        _VERSION = "0.1"
+
         warn("Experimental function. "
              "The on-disk data format for ExpressionSet is not yet fixed. "
              "Files saved using .save should not (yet) be treated as stable or future-proof.")
+
         to_path = Path(to_path)
+
         if not overwrite and to_path.exists():
             raise FileExistsError(to_path)
 
         with ZipFile(to_path, "w") as zf:
+            zf.writestr("_metadata/format-version.txt", _VERSION)
             zf.writestr("/hexels.txt", "\n".join(str(x) for x in self.hexels))
             zf.writestr("/latencies.txt", "\n".join(str(x) for x in self.latencies))
             zf.writestr("/functions.txt", "\n".join(str(x) for x in self.functions))


### PR DESCRIPTION
Addresses #13.

`ExpressionSet` instances can `.save(to_path: str, overwrite: bool)`.

The demo saves a file called something like `endtable.nkg` (extension not enforced, but maybe we want to).

The saved files can be `.load(from_path: str)`ed to recreate the `ExpressionSet`.

_This effectively is the same as saving/loading the `endtable.mat` format from the Matlab version, but sparse, and non-destructive._

## Save

The file format is just zip containing the data needed to reconstruct the `ExpressionSet`:

```
endtable.nkg (really just a .zip file)
└ functions.txt:    \n-delimited list of function names, utf8-encoded
└ hexels.txt:    \n-delimited list of hexels ids, int → str, utf8-encoded
└ latencies.txt:    \n-delimited list of latences, in seconds, float → str, utf8-encoded
└ left/:    data for left hemisphere sparse matrix
  └ coo-coords.bytes:    bytes encoding the numpy array for the coordinates in the sparse array
  └ coo-data.bytes:    bytes encoding the numpy array for the data in the sparse array
  └ coo-shape.txt:    \n-delimited list of latences, in seconds, float → str, utf8-encoded
└ right/:    data for right hemisphere sparse matrix, same format
```

`coo-shape.txt` is technically redundant, as it should be the same as the lengths of hexels, functions and latencies respectively, but a few bytes more to have this validity check seems worth it.

For now, `.save` flashes up a warning that the data format isn't finalised so backwards-incompatible changes are likely to occur.  At some point we should **finalise and version** the save format, and commit to always being able to read it in future versions of the toolbox.  Maybe save a `version.txt` file in there too.

## Load

classmethod `ExpressionSet.load(from_path: str)` loads this file and recreates the `ExpressionSet`.

## Other

This also implements `ExpressionSet.__eq__`, just so I can quickly check saving and reloading the data leads to the same structure (the demo does this).  Re-saving the same data also produces .zip archives which contain the same data (though don't have the same `md5`, for reasons I don't know) — also verified by the demo.

The demo loads 279 MB of `.mat` files (3 functions' worth of data), and the endtable save file is 1.9 MB 😎