### PR TITLE
Fixing Ylim bug

### DIFF
--- a/kymata/plot/plotting.py
+++ b/kymata/plot/plotting.py
@@ -100,7 +100,7 @@ def expression_plot(
                   bbox={'facecolor': 'white', 'edgecolor': 'none'}, verticalalignment='center')
         plot.text(600, sidak_corrected_alpha, 'α*',
                   bbox={'facecolor': 'white', 'edgecolor': 'none'}, verticalalignment='center')
-        plot.set_yticks([1, 10 ** -50, 10 ** -100, 10 ** -150])
+        plot.set_yticks(np.geomspace(start=1, stop=ylim, num=4))
 
     # format one-off axis qualities
     left_hem_expression_plot.set_title('Function Expression')


### PR DESCRIPTION
This fixes #47...

...but only if Ylim is a-log-multiple-of-4, as then there are only ticks for 1 and the Ylim.

(so with 100*-150 there are 4 ticks, but not 100*-100, where only 1, and 100*-100 are marked).

@neukym to think about.