### PR TITLE
Record the names of model selected but non plotted functions in expression plot graphs

### DIFF
--- a/kymata/plot/plotting.py
+++ b/kymata/plot/plotting.py
@@ -5,7 +5,6 @@ from typing import Optional, Sequence, Dict
 from statistics import NormalDist
 
 from matplotlib import pyplot, colors
-from matplotlib.legend_handler import HandlerLine2D
 from matplotlib.lines import Line2D
 import numpy as np
 from pandas import DataFrame
@@ -27,6 +26,7 @@ def expression_plot(
         color: Optional[str | Dict[str, str] | list[str]] = None,
         ylim: Optional[float] = None,
         xlims: Optional[tuple[Optional[float], Optional[float]]] = None,
+        hidden_functions_in_legend: bool = True,
         # I/O args
         save_to: Optional[Path] = None,
 ):
@@ -144,21 +144,29 @@ def expression_plot(
     right_hem_expression_plot.text(0, 1, '   onset of environment   ', color='white', fontsize='x-small',
                                    bbox={'facecolor': 'grey', 'edgecolor': 'none'}, verticalalignment='center',
                                    horizontalalignment='center', rotation='vertical')
-    left_hem_expression_plot.legend(handles=custom_handles, labels=custom_labels, fontsize='x-small',
-                                    title="Plotted functions", alignment="left",
-                                    bbox_to_anchor=(1.02, 1.02), loc="upper left")
-    # Plot dummy legend for other functions which are included in model selection but not plotted
-    leg = right_hem_expression_plot.legend(labels=not_shown, fontsize="x-small",
-                                           title="Non-plotted functions", alignment="left",
-                                           bbox_to_anchor=(1.02, 1.02), loc="upper left",
-                                           # Hide lines for non-plotted functions
-                                           handlelength=0, handletextpad=0)
-    for lh in leg.legendHandles:
-        lh.set_alpha(0)
+    # Legend for plotted functions
+    split_legend_at_n_functions = 15
+    legend_n_col = 2 if len(custom_handles) > split_legend_at_n_functions else 2
+    if hidden_functions_in_legend and len(not_shown) > 0:
+        if len(not_shown) > split_legend_at_n_functions:
+            legend_n_col = 2
+        # Plot dummy legend for other functions which are included in model selection but not plotted
+        leg = right_hem_expression_plot.legend(labels=not_shown, fontsize="x-small", alignment="left",
+                                               title="Non-plotted functions",
+                                               ncol=legend_n_col,
+                                               bbox_to_anchor=(1.02, -0.02), loc="lower left",
+                                               # Hide lines for non-plotted functions
+                                               handlelength=0, handletextpad=0)
+        for lh in leg.legend_handles:
+            lh.set_alpha(0)
+    left_hem_expression_plot.legend(handles=custom_handles, labels=custom_labels, fontsize='x-small', alignment="left",
+                                    title="Plotted functions",
+                                    ncol=legend_n_col,
+                                    loc="upper left", bbox_to_anchor=(1.02, 1.02))
 
     if save_to is not None:
         pyplot.rcParams['savefig.dpi'] = 300
-        pyplot.savefig(Path(save_to))
+        pyplot.savefig(Path(save_to), bbox_inches='tight')
 
     pyplot.show()
     pyplot.close()


### PR DESCRIPTION
Fixes #32.

- Non-plotted functions are automatically included in a second legend at the bottom of the figure.
- This second legend is optionally hidden, but defaults to shown when not all functions are plotted.
- If there are too many items, the legend is moved to two columns to _minimise_ (though not eliminate, in edge cases) the chance the two legends overlap.