### PR TITLE
Added causality violation score

### DIFF
--- a/kymata/ippm/data_tools.py
+++ b/kymata/ippm/data_tools.py
@@ -1,7 +1,7 @@
 import json
 from itertools import cycle
 from statistics import NormalDist
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List
 
 import matplotlib.colors
 import matplotlib.pyplot as plt
@@ -207,3 +207,25 @@ def stem_plot(
     left_hem_expression_plot.text(-275, 1, y_axis_label, verticalalignment='center',rotation='vertical')
     right_hem_expression_plot.text(0, 1, '   onset of environment   ', color='white', fontsize='x-small', bbox={'facecolor': 'grey', 'edgecolor': 'none'}, verticalalignment='center', horizontalalignment='center', rotation='vertical')
     left_hem_expression_plot.legend(handles=custom_handles, labels=custom_labels, fontsize='x-small', bbox_to_anchor=(1.2, 1))
+
+def causality_violation_score(hexels: Dict[str, IPPMHexel], hierarchy: Dict[str, List[str]], hemi: str):
+    assert(hemi == 'rightHemisphere'  or hemi == 'leftHemisphere')
+
+    def get_latency(func_hexels: IPPMHexel, mini: bool):
+        return (min(func_hexels.left_best_pairings, key=lambda x: x[0]) if hemi == 'leftHemisphere' else
+                min(func_hexels.right_best_pairings, key=lambda x: x[0])) if mini else (
+            max(func_hexels.left_best_pairings, key=lambda x: x[0]) if hemi == 'leftHemisphere' else
+            max(func_hexels.right_best_pairings, key=lambda x: x[0]))
+
+    causality_violations = 0
+    total_arrows = 0
+    for func, inc_edges in hierarchy.items():
+        # arrows go from latest inc_edge spike to the earliest func spike
+        child_latency = get_latency(hexels[func], mini=True)
+        for inc_edge in inc_edges:
+            parent_latency = get_latency(hexels[inc_edge], mini=False)
+            if child_latency < parent_latency:
+                causality_violations += 1
+            total_arrows += 1
+
+    return causality_violations / total_arrows if total_arrows != 0 else 0

--- a/tests/test_ippm_data_tools.py
+++ b/tests/test_ippm_data_tools.py
@@ -1,5 +1,4 @@
-from kymata.ippm.data_tools import IPPMHexel, build_hexel_dict_from_api_response
-
+from kymata.ippm.data_tools import IPPMHexel, build_hexel_dict_from_api_response, causality_violation_score
 
 def test_hexel():
     hexel = IPPMHexel('test', 'test description', 'test commit')
@@ -28,3 +27,56 @@ def test_build_hexel_dict():
     assert hexels['left1'].left_best_pairings == [(1, pow(10, 0.012)), (14, pow(10, 0.213))]
     assert hexels['left1'].right_best_pairings == [(51, pow(10, 0.1244))]
 
+def test_causalityViolation_With_RightHemi_Should_Succeed():
+    test_hexels = {
+        'f1' : IPPMHexel('f1'),
+        'f2' : IPPMHexel('f2'),
+        'f3' : IPPMHexel('f3'),
+        'f4' : IPPMHexel('f4')
+    }
+    test_hexels['f1'].right_best_pairings = [(50, 1e-50), (100, 1e-25)]
+    test_hexels['f2'].right_best_pairings = [(75, 1e-55), (110, 1e-77)]
+    test_hexels['f3'].right_best_pairings = [(120, 1e-39)]
+    test_hexels['f4'].right_best_pairings = [(100, 1e-19), (150, 1e-75)]
+    test_hierarchy = {
+        'f4' : ['f3'],
+        'f3' : ['f1', 'f2'],
+        'f2' : ['f1'],
+        'f1' : []
+    }
+
+    assert(causality_violation_score(test_hexels, test_hierarchy, 'rightHemisphere') == 0.5)
+
+def test_causalityViolation_With_LeftHemi_Should_Succeed():
+    test_hexels = {
+        'f1' : IPPMHexel('f1'),
+        'f2' : IPPMHexel('f2'),
+        'f3' : IPPMHexel('f3'),
+        'f4' : IPPMHexel('f4')
+    }
+    test_hexels['f1'].left_best_pairings = [(50, 1e-50), (100, 1e-25)]
+    test_hexels['f2'].left_best_pairings = [(75, 1e-55), (110, 1e-77)]
+    test_hexels['f3'].left_best_pairings = [(120, 1e-39)]
+    test_hexels['f4'].left_best_pairings = [(100, 1e-19), (150, 1e-75)]
+    test_hierarchy = {
+        'f4' : ['f3'],
+        'f3' : ['f1', 'f2'],
+        'f2' : ['f1'],
+        'f1' : []
+    }
+    assert(causality_violation_score(test_hexels, test_hierarchy, 'leftHemisphere') == 0.5)
+
+def test_causalityViolation_With_SingleFunction_Should_Return0():
+    test_hexels = {'f1' : IPPMHexel('f1')}
+    test_hexels['f1'].left_best_pairings = [(50, 1e-50), (100, 1e-25)]
+    test_hierarchy = {'f1' : []}
+
+    assert(causality_violation_score(test_hexels, test_hierarchy, 'leftHemisphere') == 0)
+
+def test_causalityViolation_With_SingleEdge_Should_Return0():
+    test_hexels = {'f1' : IPPMHexel('f1'), 'f2' : IPPMHexel('f2')}
+    test_hexels['f1'].left_best_pairings = [(50, 1e-50), (100, 1e-25)]
+    test_hexels['f2'].left_best_pairings = [(110, 1e-50)]
+    test_hierarchy = {'f2' : ['f1'], 'f1' : []}
+
+    assert(causality_violation_score(test_hexels, test_hierarchy, 'leftHemisphere') == 0)


### PR DESCRIPTION
A causality violation score has been added along with tests that calculates the proportion of arrows going backwards in time for given hexels and hierarchy. It will be used for evaluating various IPPM generation schemes.