### PR TITLE
Fix plotting tests

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from numpy import array, array_equal
 
 from kymata.datasets.sample import delete_dataset


### PR DESCRIPTION
- Some plotting tests weren't called `test_...` and so weren't being discovered by the pytest runner.
- Added a simple "do an expression plot without erroring" test.