### PR TITLE
Name files with job name and job id

### DIFF
--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -7,8 +7,8 @@
 
 
 #SBATCH --job-name=gridsearch
-#SBATCH --output=slurm_log.txt
-#SBATCH --error=slurm_log.txt
+#SBATCH --output=slurm_log-%x.%j.out.txt
+#SBATCH --error=slurm_log-%x.%j.err.txt
 #SBATCH --ntasks=1
 #SBATCH --time=05:00:00
 #SBATCH --mem=240G


### PR DESCRIPTION
`submit_gridsearch.sh` jobs will create log files which are separated by job name.

This doesn't do two things @neukym requested:
- It doesn't prefix the date (this [isn't easy/possible with slurm](https://unix.stackexchange.com/a/568616))
- It doesn't put them in a separate "logs" directory (because it could error with a weird message if the directory didn't exist)

If those two things are highly desireable, we can address them as separate issues.