### PR TITLE
Join multiple argument names into a single string

### DIFF
--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -149,12 +149,17 @@ def main():
 
     assert combined_expression_set is not None
 
+    if len(args.function_name) > 2:
+        combined_names = f"{len(args.function_name)}_functions"
+    else:
+        combined_names = "_+_".join(args.function_name)
+
     if args.save_expression_set_location is not None:
-        es_save_path = Path(args.save_expression_set_location, "_+_".join(args.function_name) + '_gridsearch.nkg')
+        es_save_path = Path(args.save_expression_set_location, combined_names + '_gridsearch.nkg')
         print(f"Saving expression set to {es_save_path!s}")
         save_expression_set(combined_expression_set, to_path_or_file=es_save_path, overwrite=args.overwrite)
 
-    fig_save_path = Path(args.save_plot_location, "_+_".join(args.function_name) + '_gridsearch.png')
+    fig_save_path = Path(args.save_plot_location, combined_names + '_gridsearch.png')
     print(f"Saving expression plot to {fig_save_path!s}")
     expression_plot(combined_expression_set, paired_axes=channel_space == "source", save_to=fig_save_path, overwrite=args.overwrite)
 


### PR DESCRIPTION
Names the files after the combination of all function names.

If 1 or 2 functions are provided, the files are named `function_...` or `function1_+_function2_...`. If more than 2 functions are provided, the files are named e.g. `250_functions_...`.