### PR TITLE
Put a `.gitignore` file in the /logs directory

### DIFF
--- a/logs/.README.md
+++ b/logs/.README.md
@@ -1,1 +1,0 @@
-## Kymata gridsearch logs

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,7 @@
+# Kymata gridsearch logs
+*.err
+*.out
+*.log
+*.err.txt
+*.out.txt
+*.log.txt


### PR DESCRIPTION
I think this is a better practice than an essentially empty text file, and it also serves a handy purpose of preventing logs getting accidentally committed.