### PR TITLE
Github action to check for new `# TODO` comments in code

### DIFF
--- a/.github/workflows/check-for-todos.yml
+++ b/.github/workflows/check-for-todos.yml
@@ -1,6 +1,10 @@
 name: Check TODO comments
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   check-todo:


### PR DESCRIPTION
CI: enforces not adding `# TODO` comments in code. Use issues instead!

Addresses #173 