### PR TITLE
Apply stimulus shift and latency correction inside gridsearch, not in the preprocessing steps

### DIFF
--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -25,7 +25,7 @@ participants: [
               ]
 number_of_runs: 2                    # number of runs  <- 15-minute recording block from scanner
 repetitions_per_runs: 2              # number of repetitions per run  <- repeated stimulus presentations per run
-stimulus_length: 400  # seconds
+stimulus_length: 400                  # seconds
 mri_structural_type: "T1"            # T1 | flash
 
 # Preprocessing pipeline

--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -46,7 +46,7 @@ inverse_operator: "interim_preprocessing_files/4_hexel_current_reconstruction/in
 audio_delivery_latency:   0.016       # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.034       # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null        # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_drift_correction:   0             # drift - in seconds per second
-visual_delivery_drift_correction:  -0.0003007    # drift - in seconds per second
-tactile_delivery_drift_correction: null          # drift - in seconds per second
+audio_delivery_drift_correction:   0             # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+visual_delivery_drift_correction:  -0.0003007    # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+tactile_delivery_drift_correction: null          # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -46,7 +46,7 @@ inverse_operator: "interim_preprocessing_files/4_hexel_current_reconstruction/in
 audio_delivery_latency:   0.016       # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.034       # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null        # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0             # drift - in seconds per second
-visual_delivery_shift_correction:  -0.0003007    # drift - in seconds per second
-tactile_delivery_shift_correction: null          # drift - in seconds per second
+audio_delivery_drift_correction:   0             # drift - in seconds per second
+visual_delivery_drift_correction:  -0.0003007    # drift - in seconds per second
+tactile_delivery_drift_correction: null          # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -46,7 +46,7 @@ inverse_operator: "interim_preprocessing_files/4_hexel_current_reconstruction/in
 audio_delivery_latency:   0.016       # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.034       # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null        # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0        # in seconds per second
-visual_delivery_shift_correction:  0        # in seconds per second
-tactile_delivery_shift_correction: null     # in seconds per second
+audio_delivery_shift_correction:   0             # drift - in seconds per second
+visual_delivery_shift_correction:  -0.0003007    # drift - in seconds per second
+tactile_delivery_shift_correction: null          # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -23,12 +23,9 @@ participants: [
                 "meg15_0081",
                 "meg15_0082"
               ]
-
-input_streams: [ "auditory" ]        # auditory | visual
-number_of_runs: 2                    # number of runs
-repetitions_per_runs: 2              # number of repetitions per run
-number_of_trials: 400                # number of trials
-trial_length: 1                      # seconds
+number_of_runs: 2                    # number of runs  <- 15-minute recording block from scanner
+repetitions_per_runs: 2              # number of repetitions per run  <- repeated stimulus presentations per run
+stimulus_length: 400  # seconds
 mri_structural_type: "T1"            # T1 | flash
 
 # Preprocessing pipeline
@@ -46,12 +43,10 @@ meg: False
 inverse_operator: "interim_preprocessing_files/4_hexel_current_reconstruction/inverse-operators"
 
 # Creation of evoked trial pipeline
-audio_delivery_latency:   0.026     # in seconds
-visual_delivery_latency:  0.017     # in seconds
-tactile_delivery_latency: 0.000     # in seconds
-audio_delivery_shift_correction: 0  # in seconds per second
+audio_delivery_latency:   0.026       # the audio stimulus is delayed by this amount in seconds
+visual_delivery_latency:  0.017       # the visual stimulus is delayed by this amount in seconds
+tactile_delivery_latency: 0.000       # the tactile stimulus is delayed by this amount in seconds
+audio_delivery_shift_correction:   0  # in seconds per second
+visual_delivery_shift_correction:  0  # in seconds per second
+tactile_delivery_shift_correction: 0  # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds
-
-eeg_thresh:  1  # 200e-6
-grad_thresh: 1  # 4000e-13
-mag_thresh:  1  # 4000e-15

--- a/dataset_config/dataset3.yaml
+++ b/dataset_config/dataset3.yaml
@@ -43,10 +43,10 @@ meg: False
 inverse_operator: "interim_preprocessing_files/4_hexel_current_reconstruction/inverse-operators"
 
 # Creation of evoked trial pipeline
-audio_delivery_latency:   0.026       # the audio stimulus is delayed by this amount in seconds
-visual_delivery_latency:  0.017       # the visual stimulus is delayed by this amount in seconds
-tactile_delivery_latency: 0.000       # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0  # in seconds per second
-visual_delivery_shift_correction:  0  # in seconds per second
-tactile_delivery_shift_correction: 0  # in seconds per second
+audio_delivery_latency:   0.016       # the audio stimulus is delayed by this amount in seconds
+visual_delivery_latency:  0.034       # the visual stimulus is delayed by this amount in seconds
+tactile_delivery_latency: null        # the tactile stimulus is delayed by this amount in seconds
+audio_delivery_shift_correction:   0        # in seconds per second
+visual_delivery_shift_correction:  0        # in seconds per second
+tactile_delivery_shift_correction: null     # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.1.yaml
+++ b/dataset_config/dataset4.1.yaml
@@ -9,11 +9,9 @@ mri_structurals_directory: "raw_mri_structurals"
 participants: [
                 'pilot_01',
               ]
-input_streams: [ "auditory" ]        # auditory | visual
 number_of_runs: 4                    # number of runs
 repetitions_per_runs: 2              # number of repetitions per run
-number_of_trials: 400                # number of trials
-trial_length: 1                      # seconds
+stimulus_length: 400  # seconds
 mri_structural_type: "T1"            # T1 | flash
 
 # Preprocessing pipeline
@@ -39,9 +37,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # in seconds
 visual_delivery_latency:  0.017     # in seconds
 tactile_delivery_latency: 0.00      # in seconds
-audio_delivery_shift_correction: 0.0005410   # in seconds per second
+audio_delivery_shift_correction:   0.0005404  # in seconds per second
+visual_delivery_shift_correction:  0          # in seconds per second
+tactile_delivery_shift_correction: 0          # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds
-
-eeg_thresh:  1 #200e-6
-grad_thresh: 1 #4000e-13
-mag_thresh:  1 #4000e-15

--- a/dataset_config/dataset4.1.yaml
+++ b/dataset_config/dataset4.1.yaml
@@ -37,7 +37,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_drift_correction:   0.0005404     # drift - in seconds per second
-visual_delivery_drift_correction:  0.00049       # drift - in seconds per second
-tactile_delivery_drift_correction: null          # drift - in seconds per second
+audio_delivery_drift_correction:   0.0005404     # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+visual_delivery_drift_correction:  0.00049       # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+tactile_delivery_drift_correction: null          # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.1.yaml
+++ b/dataset_config/dataset4.1.yaml
@@ -37,7 +37,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0.0005404  # in seconds per second
-visual_delivery_shift_correction:  0          # in seconds per second
-tactile_delivery_shift_correction: null       # in seconds per second
+audio_delivery_shift_correction:   0.0005404     # drift - in seconds per second
+visual_delivery_shift_correction:  0.00049       # drift - in seconds per second
+tactile_delivery_shift_correction: null          # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.1.yaml
+++ b/dataset_config/dataset4.1.yaml
@@ -34,10 +34,10 @@ duration:   1                      # in seconds for the duration of the empty ro
 reg_method: 'empirical'            # None | 'auto'
 
 # Creation of evoked trial pipeline
-audio_delivery_latency:   0.026     # in seconds
-visual_delivery_latency:  0.017     # in seconds
-tactile_delivery_latency: 0.00      # in seconds
+audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
+visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
+tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
 audio_delivery_shift_correction:   0.0005404  # in seconds per second
 visual_delivery_shift_correction:  0          # in seconds per second
-tactile_delivery_shift_correction: 0          # in seconds per second
+tactile_delivery_shift_correction: null       # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.1.yaml
+++ b/dataset_config/dataset4.1.yaml
@@ -37,7 +37,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0.0005404     # drift - in seconds per second
-visual_delivery_shift_correction:  0.00049       # drift - in seconds per second
-tactile_delivery_shift_correction: null          # drift - in seconds per second
+audio_delivery_drift_correction:   0.0005404     # drift - in seconds per second
+visual_delivery_drift_correction:  0.00049       # drift - in seconds per second
+tactile_delivery_drift_correction: null          # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -32,7 +32,7 @@ participants: [
               ]
 number_of_runs: 4                    # number of runs
 repetitions_per_runs: 2              # number of repetitions per run
-stimulus_length: 400  # seconds
+stimulus_length: 400                 # seconds
 mri_structural_type: "T1"            # T1 | flash
 
 # Preprocessing pipeline

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -58,7 +58,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0.0005404  # in seconds per second
-visual_delivery_shift_correction:  0          # in seconds per second
-tactile_delivery_shift_correction: null       # in seconds per second
+audio_delivery_shift_correction:   0.0005404  # drift - in seconds per second
+visual_delivery_shift_correction:  0          # drift - in seconds per second
+tactile_delivery_shift_correction: null       # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -58,7 +58,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_shift_correction:   0.0005404  # drift - in seconds per second
-visual_delivery_shift_correction:  0          # drift - in seconds per second
-tactile_delivery_shift_correction: null       # drift - in seconds per second
+audio_delivery_drift_correction:   0.0005404  # drift - in seconds per second
+visual_delivery_drift_correction:  0          # drift - in seconds per second
+tactile_delivery_drift_correction: null       # drift - in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -30,11 +30,9 @@ participants: [
                 'participant_18',
                 'participant_19'
               ]
-input_streams: [ "auditory" ]        # auditory | visual
 number_of_runs: 4                    # number of runs
 repetitions_per_runs: 2              # number of repetitions per run
-number_of_trials: 400                # number of trials
-trial_length: 1                      # seconds
+stimulus_length: 400  # seconds
 mri_structural_type: "T1"            # T1 | flash
 
 # Preprocessing pipeline
@@ -60,9 +58,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # in seconds
 visual_delivery_latency:  0.017     # in seconds
 tactile_delivery_latency: 0.00      # in seconds
-audio_delivery_shift_correction: 0.0005404   # in seconds per second
+audio_delivery_shift_correction:   0.0005404  # in seconds per second
+visual_delivery_shift_correction:  0          # in seconds per second
+tactile_delivery_shift_correction: 0          # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds
-
-eeg_thresh: 1 #200e-6
-grad_thresh: 1 #4000e-13
-mag_thresh: 1 #4000e-15

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -55,10 +55,10 @@ duration:   1                      # in seconds for the duration of the empty ro
 reg_method: 'empirical'            # None | 'auto'
 
 # Creation of evoked trial pipeline
-audio_delivery_latency:   0.026     # in seconds
-visual_delivery_latency:  0.017     # in seconds
-tactile_delivery_latency: 0.00      # in seconds
+audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
+visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
+tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
 audio_delivery_shift_correction:   0.0005404  # in seconds per second
 visual_delivery_shift_correction:  0          # in seconds per second
-tactile_delivery_shift_correction: 0          # in seconds per second
+tactile_delivery_shift_correction: null       # in seconds per second
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/dataset_config/dataset4.yaml
+++ b/dataset_config/dataset4.yaml
@@ -58,7 +58,7 @@ reg_method: 'empirical'            # None | 'auto'
 audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_drift_correction:   0.0005404  # drift - in seconds per second
-visual_delivery_drift_correction:  0          # drift - in seconds per second
-tactile_delivery_drift_correction: null       # drift - in seconds per second
+audio_delivery_drift_correction:   0.0005404  # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+visual_delivery_drift_correction:  0          # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+tactile_delivery_drift_correction: null       # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/invokers/invoker_create_trialwise_data.py
+++ b/invokers/invoker_create_trialwise_data.py
@@ -15,16 +15,8 @@ def main(config_filename: str):
         dataset_directory_name=config['dataset_directory_name'],
         list_of_participants=config['participants'],
         repetitions_per_runs=config['repetitions_per_runs'],
+        stimulus_length=config['stimulus_lengths'],
         number_of_runs=config['number_of_runs'],
-        number_of_trials=config['number_of_trials'],
-        input_streams=config['input_streams'],
-        eeg_thresh=float(config['eeg_thresh']),
-        grad_thresh=float(config['grad_thresh']),
-        mag_thresh=float(config['mag_thresh']),
-        visual_delivery_latency=config['visual_delivery_latency'],
-        audio_delivery_latency=config['audio_delivery_latency'],
-        audio_delivery_shift_correction=config['audio_delivery_shift_correction'],
-        trial_length=config["trial_length"],
         latency_range=config["latency_range"],
     )
 

--- a/invokers/invoker_create_trialwise_data.py
+++ b/invokers/invoker_create_trialwise_data.py
@@ -15,7 +15,7 @@ def main(config_filename: str):
         dataset_directory_name=config['dataset_directory_name'],
         list_of_participants=config['participants'],
         repetitions_per_runs=config['repetitions_per_runs'],
-        stimulus_length=config['stimulus_lengths'],
+        stimulus_length=config['stimulus_length'],
         number_of_runs=config['number_of_runs'],
         latency_range=config["latency_range"],
     )

--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -94,7 +94,7 @@ def main():
 
     reps = [f'_rep{i}' for i in range(8)] + ['-ave']  # most of the time we will only use the -ave, not the individual reps
     if args.single_participant_override is not None:
-        emeg_filenames = [args.single_participant_override + f"-ave"]
+        emeg_filenames = [ f"{args.single_participant_override}-ave" ]
     else:
         emeg_filenames = [
             p + r

--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -81,13 +81,13 @@ def main():
 
     input_stream = args.input_stream
     if input_stream == "auditory":
-        stimulus_shift_correction = dataset_config["audio_shift_correction"]
+        stimulus_shift_correction = dataset_config["audio_delivery_drift_correction"]
         stimulus_delivery_latency = dataset_config["audio_delivery_latency"]
     elif input_stream == "visual":
-        stimulus_shift_correction = dataset_config["visual_shift_correction"]
+        stimulus_shift_correction = dataset_config["visual_delivery_drift_correction"]
         stimulus_delivery_latency = dataset_config["visual_delivery_latency"]
     elif input_stream == "tactile":
-        stimulus_shift_correction = dataset_config["tactile_shift_correction"]
+        stimulus_shift_correction = dataset_config["tactile_delivery_drift_correction"]
         stimulus_delivery_latency = dataset_config["tactile_delivery_latency"]
     else:
         raise NotImplementedError()

--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -94,12 +94,18 @@ def main():
 
     reps = [f'_rep{i}' for i in range(8)] + ['-ave']  # most of the time we will only use the -ave, not the individual reps
     if args.single_participant_override is not None:
-        emeg_filenames = [ f"{args.single_participant_override}-ave" ]
+        if args.ave_mode == 'ave':
+            emeg_filenames = [args.single_participant_override + "-ave"]
+        elif args.ave_mode == 'concatenate':
+            print('Concatenating repetitions together')
+            emeg_filenames = [
+                args.single_participant_override + r
+                for r in reps[:-1]
+            ]
     else:
         emeg_filenames = [
-            p + r
+            p + '-ave'
             for p in participants
-            for r in reps[-1:]  # [-1:] means just use the -ave
         ]
 
     start = time.time()

--- a/kymata/gridsearch/plain.py
+++ b/kymata/gridsearch/plain.py
@@ -124,6 +124,8 @@ def do_gridsearch(
     emeg_stds = get_stds(emeg_reshaped, n_func_samples_per_split)
     emeg_reshaped = np.fft.rfft(emeg_reshaped, n=n_samples_per_split, axis=-1)
     F_func = np.conj(np.fft.rfft(normalize(func), n=n_samples_per_split, axis=-1))
+    if n_reps > 1:
+        F_func = np.tile(F_func, (n_reps, 1))
     corrs = np.zeros((n_channels, n_derangements + 1, n_splits * n_reps, n_func_samples_per_split))
     for der_i, derangement in enumerate(derangements):
         deranged_emeg = emeg_reshaped[:, derangement, :]

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -465,6 +465,9 @@ def create_trialwise_data(data_root_dir: PathType,
 
         raw_events = mne.find_events(raw, stim_channel=CHANNEL_TRIGGER, shortest_event=1)
         repetition_events = mne.pick_events(raw_events, include=TRIGGER_REP_ONSET)
+        # name repetitions
+        for i in range(len(repetition_events)):
+            repetition_events[i][2] = str(i)
 
         # Validate repetition events
         assert len(repetition_events) == number_of_runs * repetitions_per_runs

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from colorama import Fore, Style
 import mne
-from numpy import zeros, nanmin
+from numpy import nanmin
 from pandas import DataFrame, Index
 from pathlib import Path
 from matplotlib import pyplot as plt

--- a/kymata/preproc/source.py
+++ b/kymata/preproc/source.py
@@ -307,7 +307,7 @@ def load_emeg_pack(emeg_filenames,
 
     # Load remaining ones in using the appropriate ave_mode
     if ave_mode == 'concatenate':
-        # Concatenating all reps into a single long stimulus, in single-participant-override mode
+        # Concatenating all reps (or participant_averages - although this would be a non-standard use) into a single long stimulus
 
         for i in range(1, len(emeg_paths)):
             new_emeg, _ch_names = load_single_emeg(emeg_paths[i], need_names, inverse_operator_paths[i], snr,

--- a/kymata/preproc/source.py
+++ b/kymata/preproc/source.py
@@ -63,10 +63,6 @@ def load_single_emeg(emeg_path: Path, need_names=False, inverse_operator=None, s
             evoked = mne.read_evokeds(emeg_path_fif, verbose=False)  # should be len 1 list
             emeg = evoked[0].get_data()  # numpy array shape (sensor_num, N) = (370, 403_001)
             ch_names = evoked[0].ch_names
-            if not isfile(emeg_path_npy):
-                np.save(emeg_path_npy, np.array(emeg, dtype=np.float16))
-            if not isfile(ch_names_path):
-                np.save(ch_names_path, ch_names)
             del evoked
 
     return emeg, ch_names
@@ -308,7 +304,6 @@ def load_emeg_pack(emeg_filenames,
     # Load remaining ones in using the appropriate ave_mode
     if ave_mode == 'concatenate':
         # Concatenating all reps (or participant_averages - although this would be a non-standard use) into a single long stimulus
-
         for i in range(1, len(emeg_paths)):
             new_emeg, _ch_names = load_single_emeg(emeg_paths[i], need_names, inverse_operator_paths[i], snr,
                                         morph_paths[i], old_morph=old_morph, invsol_npy_path=invsol_paths[i],

--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -27,6 +27,7 @@ apptainer exec \
       export VENV_PATH=~/poetry/ ; \
       \$VENV_PATH/bin/poetry run python -m invokers.run_gridsearch \
         --config dataset4.yaml \
+        --input_stream auditory \
         --function-path 'predicted_function_contours/GMSloudness/stimulisig' \
         --function-name IL STL \
         --overwrite

--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -23,7 +23,7 @@ apptainer exec \
   -B /imaging/projects/cbu/kymata/ \
   /imaging/local/software/singularity_images/python/python_3.11.7-slim.sif \
   bash -c \
-    " cd /imaging/projects/cbu/kymata/analyses/andy/kymata-toolbox/ ; \
+    " cd /imaging/projects/cbu/kymata/analyses/andy/kymata-core/ ; \
       export VENV_PATH=~/poetry/ ; \
       \$VENV_PATH/bin/poetry run python -m invokers.run_gridsearch \
         --config dataset4.yaml \

--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -29,7 +29,7 @@ apptainer exec \
         --config dataset4.yaml \
         --input-stream auditory \
         --function-path 'predicted_function_contours/GMSloudness/stimulisig' \
-        --function-name IL STL \
+        --function-name IL STL IL1 IL2 IL3 IL4 IL5 IL6 IL7 IL8 IL9  \
         --overwrite
   "
   #  --snr $ARG # >> result3.txt

--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -27,7 +27,7 @@ apptainer exec \
       export VENV_PATH=~/poetry/ ; \
       \$VENV_PATH/bin/poetry run python -m invokers.run_gridsearch \
         --config dataset4.yaml \
-        --input_stream auditory \
+        --input-stream auditory \
         --function-path 'predicted_function_contours/GMSloudness/stimulisig' \
         --function-name IL STL \
         --overwrite


### PR DESCRIPTION
## The problem

On running gridsearch on visual functions on the Russian dataset, I found that it was working but the latency was obviously wrong:

![MicrosoftTeams-image](https://github.com/kymata-atlas/kymata-core/assets/5602172/63608fcb-791b-4d53-b0bb-841dd980a348)

On searching through the code, @neukym and I realised the mistake: the data preprocessing was applying latency correction for audio-delivered stimuli, but this wasn't actually being used, and the gridsearch was applying latency-stretch correction for audio-delivered stimuli; and neither were implemented for visual-delivered stimuli.

After discussion with @neukym, we decided that because the shift/stretch correction is (potentially) different for each stimulus-delivery modality, it makes sense to do this online, tailored to the specific function being run, during the _gridsearch_, instead of separately preprocessing the trialwise data for each modality.

## This PR

- Removes all shift/stretch correction from the preprocessing and adds it into the gridsearch.
  - Fixes #286 
- Adds a new CLI argument `--input-stream [auditory|visual|tactile]` to the gridsearch invoker, which applies the appropriate corrections for that modality
  - Genericises the correction away from `audio_shift_correction` alone
  - Adds other-modality fields to all the config files
  - Fixes #285
- Preprocessing doesn't any longer edit events and know about slices, instead it has a simple set of validation checks
  - Fixes #284
  - Second validation check not yet implemented, moved to new issue: #289
- Hopefully solves the original problem of gridsearch not working on visual functions
  - Fixes #287 

## For the reviewer

@ollieparish I'm asking you for review as you wrote most of this code!  A few questions and notes we had while reading/writing the code.

- [x] Can you verify that we understand what the `ave_mode` argument is doing?  We've written our understanding into comments which hopefully are accurate (please correct as necessary).
  - [x] In particular, please verify that things behave correctly when using `ave_mode == "concatenate"`: we understand this to be concatenating repetitions into one long stimulus, and that it is to be only used in `single_participant_override` mode (to prevent concatenating multiple participants data into one).  But in particular in this case would we also need to concatenate the function onto itself?
- [x] There are lots of `* 2` and `// 2` in `do_gridsearch`.  Please could you verify that this is doing what it should and add a brief comment as to what they're doing?

@neukym - request for testing to confirm syntax breaks and results matches the previous results.

  - [x] TVL Russian
  - [x] TVL English
  - [x]  CIECAM02 Russian

## Also covered in this PR (via @neukym)

- Added `visual_delivery_latency`, `tactile_delivery_latency`, `visual_delivery_shift_correction` and `tactile_delivery_shift_correction` fields to _all_ the config files (covered by a different issue, #291) 


