### PR TITLE
Option to plot top five channels

### DIFF
--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -69,6 +69,7 @@ def main():
     parser.add_argument('--save-name', type=str, required=False, help="Specify the name of the saved .nkg file.")
     parser.add_argument('--save-expression-set-location', type=Path, default=Path(_default_output_dir), help="Save the results of the gridsearch into an ExpressionSet .nkg file")
     parser.add_argument('--save-plot-location', type=Path, default=Path(_default_output_dir), help="Save an expression plots, and other plots, in this location")
+    parser.add_argument('--plot-top-channels', type=bool, action="store_true", help="Plots the p-values and correlations of the top channels in the gridsearch.")
 
     args = parser.parse_args()
 
@@ -179,6 +180,7 @@ def main():
             emeg_t_start=args.emeg_t_start,
             stimulus_shift_correction=stimulus_shift_correction,
             stimulus_delivery_latency=stimulus_delivery_latency,
+            plot_top_five_channels=args.plot_top_channels,
             overwrite=args.overwrite,
         )
 

--- a/kymata/gridsearch/plain.py
+++ b/kymata/gridsearch/plain.py
@@ -31,6 +31,7 @@ def do_gridsearch(
         seconds_per_split: float = 1,
         n_splits: int = 400,
         n_reps: int = 1,
+        plot_top_five_channels: bool = False,
         overwrite: bool = True,
 ) -> ExpressionSet:
     """
@@ -61,6 +62,8 @@ def do_gridsearch(
         seconds_per_split (float, optional): Duration of each split in seconds. Default is 0.5 seconds.
         n_splits (int, optional): Number of splits used for analysis. Default is 800.
         n_reps (int, optional): Number of repetitions for each split. Default is 1.
+        plot_top_five_channels (bool, optional): Plots the p-values and correlation values of the top
+            five channels in the gridsearch. Default is False.
         overwrite (bool, optional): Whether to overwrite existing plot files. Default is True.
 
     Returns:
@@ -151,17 +154,18 @@ def do_gridsearch(
 
     latencies_ms = np.linspace(start_latency, start_latency + (seconds_per_split * 1000), n_func_samples_per_split + 1)[:-1]
 
-    plot_top_five_channels_of_gridsearch(
-        corrs=corrs,
-        auto_corrs=auto_corrs,
-        function=function,
-        n_reps=n_reps,
-        n_splits=n_splits,
-        n_samples_per_split=n_samples_per_split,
-        latencies=latencies_ms,
-        save_to=plot_location,
-        log_pvalues=log_pvalues,
-        overwrite=overwrite,
+    if plot_top_five_channels:
+        plot_top_five_channels_of_gridsearch(
+            corrs=corrs,
+            auto_corrs=auto_corrs,
+            function=function,
+            n_reps=n_reps,
+            n_splits=n_splits,
+            n_samples_per_split=n_samples_per_split,
+            latencies=latencies_ms,
+            save_to=plot_location,
+            log_pvalues=log_pvalues,
+            overwrite=overwrite,
         )
 
     if channel_space == "sensor":

--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -30,6 +30,7 @@ apptainer exec \
         --input-stream auditory \
         --function-path 'predicted_function_contours/GMSloudness/stimulisig' \
         --function-name IL STL IL1 IL2 IL3 IL4 IL5 IL6 IL7 IL8 IL9  \
+        --plot-top-channels \
         --overwrite
   "
   #  --snr $ARG # >> result3.txt


### PR DESCRIPTION
Adds new `--plot-top-channels` option to the gridsearch which causes it to do the previous functionality of plotting the p-values and correlations for the top five channels.

Fixes #318 