### PR TITLE
Function to combine a list of ExpressionSets

### DIFF
--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -366,17 +366,20 @@ class HexelExpressionSet(ExpressionSet):
         )
 
     def __copy__(self):
+        data_left:  NDArray = self._data[BLOCK_LEFT].data.todense()
+        data_right: NDArray = self._data[BLOCK_RIGHT].data.todense()
         return HexelExpressionSet(
             functions=self.functions.copy(),
             hexels_lh=self.hexels_left.copy(),
             hexels_rh=self.hexels_right.copy(),
             latencies=self.latencies.copy(),
-            data_lh=self._data[BLOCK_LEFT].values.copy(),
-            data_rh=self._data[BLOCK_RIGHT].values.copy(),
+            # Slice by function
+            data_lh=[data_left[:, :, i].copy() for i in range(data_left.shape[2])],
+            data_rh=[data_right[:, :, i].copy() for i in range(data_right.shape[2])],
         )
 
     def __add__(self, other: HexelExpressionSet) -> HexelExpressionSet:
-        self._add_compatible(other)
+        self._add_compatibility_check(other)
         assert array_equal(self.hexels_left, other.hexels_left), "Hexels mismatch (left)"
         assert array_equal(self.hexels_right, other.hexels_right), "Hexels mismatch (right)"
         assert array_equal(self.latencies, other.latencies), "Latencies mismatch"
@@ -479,11 +482,13 @@ class SensorExpressionSet(ExpressionSet):
         return True
 
     def __copy__(self):
+        data: NDArray = self._data[BLOCK_SCALP].data.todense()
         return SensorExpressionSet(
             functions=self.functions.copy(),
             sensors=self.sensors.copy(),
             latencies=self.latencies.copy(),
-            data=self._data[BLOCK_SCALP].values.copy(),
+            # Slice by function
+            data=[data[:, :, i].copy() for i in range(data.shape[2])],
         )
 
     def __add__(self, other: SensorExpressionSet) -> SensorExpressionSet:

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -5,7 +5,7 @@ Classes and functions for storing expression information.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence, Union, get_args, Tuple, Collection, Self, TypeVar
+from typing import Sequence, Union, get_args, Tuple, TypeVar
 from warnings import warn
 
 from numpy import array, array_equal, ndarray

--- a/kymata/io/functions.py
+++ b/kymata/io/functions.py
@@ -13,7 +13,7 @@ from kymata.io.file import PathType
 _logger = getLogger(__file__)
 
 
-def load_function(function_path_without_suffix: PathType, func_name: str, replace_nans: Optional[bool] = None,
+def load_function(function_path_without_suffix: PathType, func_name: str, replace_nans: Optional[str] = None,
                   n_derivatives: int = 0, bruce_neurons: tuple = (0, 10)) -> Function:
     function_path_without_suffix = Path(function_path_without_suffix)
     func: NDArray

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -68,17 +68,17 @@ def sensor_expression_set_4_sensors_4_latencies() -> SensorExpressionSet:
     from numpy.typing import NDArray
     sensors = [str(i) for i in range(4)]
     function_a_data: NDArray = array(p_to_logp(array([
-        # 0   1   2  latencies
-        [1,  .1,  1],  # 0
-        [1,   1, .2],  # 1
-        [.1,  1,  1],  # 2
-        [.2,  1,  1],  # 3 sensors
+        # 0   1   2   3  latencies
+        [1,  .1,  1,  1],  # 0
+        [1,   1, .2,  1],  # 1
+        [.1,  1,  1,  1],  # 2
+        [.2,  1,  1,  1],  # 3 sensors
     ])))
     function_b_data: NDArray = array(p_to_logp(array([
-        [1,   1, .2],
-        [1,  .1,  1],
-        [1,  .2,  1],
-        [1,   1, .1],
+        [1,   1, .2,  1],
+        [1,  .1,  1,  1],
+        [1,  .2,  1,  1],
+        [1,   1, .1,  1],
     ])))
     return SensorExpressionSet(functions=["a", "b"],
                                sensors=sensors,  # 4
@@ -92,17 +92,17 @@ def sensor_expression_set_4_sensors_4_different_latencies() -> SensorExpressionS
     from numpy.typing import NDArray
     sensors = [str(i) for i in range(4)]
     function_a_data: NDArray = array(p_to_logp(array([
-        # 0   1   2  latencies
-        [1,  .1,  1],  # 0
-        [1,   1, .2],  # 1
-        [.1,  1,  1],  # 2
-        [.2,  1,  1],  # 3 sensors
+        # 0   1   2   3  latencies
+        [1,  .1,  1,  1],  # 0
+        [1,   1, .2,  1],  # 1
+        [.1,  1,  1,  1],  # 2
+        [.2,  1,  1,  1],  # 3 sensors
     ])))
     function_b_data: NDArray = array(p_to_logp(array([
-        [1,   1, .2],
-        [1,  .1,  1],
-        [1,  .2,  1],
-        [1,   1, .1],
+        [1,   1, .2,  1],
+        [1,  .1,  1,  1],
+        [1,  .2,  1,  1],
+        [1,   1, .1,  1],
     ])))
     return SensorExpressionSet(functions=["a", "b"],
                                sensors=sensors,  # 4

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -432,8 +432,10 @@ def test_combine_vaild_ses_works(sensor_expression_set_4_sensors):
         for f in ses_2.functions
     })
     combined = combine([ses_1, ses_2])
-    assert ses_1.sensors == ses_2.sensors == combined.sensors
-    assert ses_1.latencies == ses_2.latencies == combined.latencies
+    assert np.array_equal(combined.sensors, ses_1.sensors)
+    assert np.array_equal(combined.sensors, ses_2.sensors)
+    assert np.array_equal(combined.latencies, ses_1.latencies)
+    assert np.array_equal(combined.latencies, ses_2.latencies)
     assert set(ses_1.functions) | set(ses_2.functions) == set(combined.functions)
 
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -114,7 +114,7 @@ def sensor_expression_set_4_sensors_4_different_latencies() -> SensorExpressionS
 def sensor_expression_set_5_sensors() -> SensorExpressionSet:
     from numpy import array
     from numpy.typing import NDArray
-    sensors = [str(i) for i in range(4)]
+    sensors = [str(i) for i in range(5)]
     function_a_data: NDArray = array(p_to_logp(array([
         # 0   1   2  latencies
         [1,  .1,  1],  # 0
@@ -487,28 +487,32 @@ def test_combine_vaild_ses_works(sensor_expression_set_4_sensors_3_latencies):
     assert set(ses_1.functions) | set(ses_2.functions) == set(combined.functions)
 
 
-def test_combine_fails_with_mixed_types(hexel_expression_set_5_hexels, sensor_expression_set_4_sensors_3_latencies):
+def test_combine_fails_with_mixed_types(hexel_expression_set_5_hexels,
+                                        sensor_expression_set_4_sensors_3_latencies):
     with pytest.raises(ValueError):
         combine([hexel_expression_set_5_hexels, sensor_expression_set_4_sensors_3_latencies])
 
 
-def test_combine_fails_with_mismatched_sensor_counts(sensor_expression_set_4_sensors_3_latencies, sensor_expression_set_5_sensors):
+def test_combine_fails_with_mismatched_sensor_counts(sensor_expression_set_4_sensors_3_latencies,
+                                                     sensor_expression_set_5_sensors):
     with pytest.raises(ValueError):
         combine([sensor_expression_set_4_sensors_3_latencies, sensor_expression_set_5_sensors])
 
 
 def test_combine_fails_with_mismatched_sensor_names(sensor_expression_set_4_sensors_3_latencies):
     ses_renamed_sensors: SensorExpressionSet = copy(sensor_expression_set_4_sensors_3_latencies)
-    ses_renamed_sensors.rename(channels={c: c+1 for c in sensor_expression_set_4_sensors_3_latencies.sensors})
+    ses_renamed_sensors.rename(channels={c: f"{c}'" for c in sensor_expression_set_4_sensors_3_latencies.sensors})
     with pytest.raises(ValueError):
         combine([sensor_expression_set_4_sensors_3_latencies, ses_renamed_sensors])
 
 
-def test_combine_fails_with_mismatched_latency_counts(sensor_expression_set_4_sensors_3_latencies, sensor_expression_set_4_sensors_4_latencies):
+def test_combine_fails_with_mismatched_latency_counts(sensor_expression_set_4_sensors_3_latencies,
+                                                      sensor_expression_set_4_sensors_4_latencies):
     with pytest.raises(ValueError):
         combine([sensor_expression_set_4_sensors_3_latencies, sensor_expression_set_4_sensors_4_latencies])
 
 
-def test_combine_fails_with_mismatched_latencies(sensor_expression_set_4_sensors_4_latencies, sensor_expression_set_4_sensors_4_different_latencies):
+def test_combine_fails_with_mismatched_latencies(sensor_expression_set_4_sensors_4_latencies,
+                                                 sensor_expression_set_4_sensors_4_different_latencies):
     with pytest.raises(ValueError):
         combine([sensor_expression_set_4_sensors_4_latencies, sensor_expression_set_4_sensors_4_different_latencies])


### PR DESCRIPTION
- New `combine([es_1, es_2, ...])` function which is equivalent to `es_1 + es_2 + ...`.
- Adds a bunch of tests to `test_expression.py`!
- Modifies `ExpressionSets.rename()` to allow renaming of channels (used in the new tests)
- Touches on #271  because it fixes a bug in `__copy__` which related to automatic densification of a sparse array, which is also a problem in #271 