### PR TITLE
Normalize bug

### DIFF
--- a/invokers/run_gridsearch.py
+++ b/invokers/run_gridsearch.py
@@ -51,7 +51,6 @@ def main():
     parser.add_argument('--function-name', type=str, nargs="+", help='function names in stimulisig')
     parser.add_argument('--function-path', type=str, default='predicted_function_contours/GMSloudness/stimulisig', help='location of function stimulisig')
     parser.add_argument('--replace-nans', type=str, required=False, choices=["zero", "mean"], default=None, help="If the function contour contains NaN values, this will replace them with the specified values.")
-    parser.add_argument('--add-noise', action="store_true", help="Add a small amount of noise to avoid issues arising from constant functions.")
 
     # For source space
     parser.add_argument('--use-inverse-operator',    action="store_true", help="Use inverse operator to conduct gridsearch in source space.")
@@ -166,7 +165,7 @@ def main():
         function_values = load_function(Path(base_dir, args.function_path),
                                         func_name=function_name,
                                         replace_nans=args.replace_nans,
-                                        bruce_neurons=(5, 10), add_noise=args.add_noise)
+                                        bruce_neurons=(5, 10))
         function_values = function_values.downsampled(args.downsample_rate)
 
         es = do_gridsearch(

--- a/kymata/io/functions.py
+++ b/kymata/io/functions.py
@@ -14,7 +14,7 @@ _logger = getLogger(__file__)
 
 
 def load_function(function_path_without_suffix: PathType, func_name: str, replace_nans: Optional[bool] = None,
-                  n_derivatives: int = 0, bruce_neurons: tuple = (0, 10), add_noise: bool = False) -> Function:
+                  n_derivatives: int = 0, bruce_neurons: tuple = (0, 10)) -> Function:
     function_path_without_suffix = Path(function_path_without_suffix)
     func: NDArray
     if 'neurogram' in func_name:
@@ -74,12 +74,8 @@ def load_function(function_path_without_suffix: PathType, func_name: str, replac
             func[np.isnan(func)] = np.nanmean(func)
         else:
             raise NotImplementedError()
-    assert not np.isnan(func).any()
 
-    if add_noise:
-        # Add 0.1% gaussian noise
-        range_ = func[func != 0].max() - func[func != 0].min()
-        func += np.random.normal(size=func.shape, scale=range_ / 1000)
+    assert not np.isnan(func).any()
 
     for _ in range(n_derivatives):
         func = np.convolve(func, [-1, 1], 'same')  # derivative

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -23,7 +23,7 @@ def normalize(x: NDArray, inplace: bool = False) -> NDArray:
 
 
 def _magnitude(x: NDArray) -> float:
-    return np.sqrt(np.sum(x**2, axis=-1, keepdims=True)).item()
+    return np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
 
 
 def get_stds(x: NDArray, n: int):

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -2,10 +2,14 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-def normalize(x: NDArray) -> NDArray:
+def normalize(x: NDArray, inplace: bool = False) -> NDArray:
     """
     Remove the mean and divide by the Euclidean magnitude.
+    If inplace is True, the array will be modified in place. If false, a normalized copy will be returned.
     """
+    if not inplace:
+        x = np.copy(x)
+
     x -= np.mean(x, axis=-1, keepdims=True)
     x /= np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
     return x

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -15,14 +15,14 @@ def normalize(x: NDArray, inplace: bool = False) -> NDArray:
     # In case the values of x are very small, sometimes _magnitude can return 0, which would cause a divide by zero
     # error. Having already centred x, we can upscale it before downscaling it to avoid this issue. In case the
     # _magnitude should actually be 0, this won't make a difference to that.
-    if _magnitude(x) == 0:
+    if (_magnitude(x) == 0).all():
         x *= 1_000_000
     x /= _magnitude(x)
 
     return x
 
 
-def _magnitude(x: NDArray) -> float:
+def _magnitude(x: NDArray) -> NDArray:
     return np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
 
 

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -12,6 +12,9 @@ def normalize(x: NDArray, inplace: bool = False) -> NDArray:
 
     x -= np.mean(x, axis=-1, keepdims=True)
 
+    # In case the values of x are very small, sometimes _magnitude can return 0, which would cause a divide by zero
+    # error. Having already centred x, we can upscale it before downscaling it to avoid this issue. In case the
+    # _magnitude should actually be 0, this won't make a difference to that.
     if _magnitude(x) == 0:
         x *= 1000
     x /= _magnitude(x)

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -16,7 +16,7 @@ def normalize(x: NDArray, inplace: bool = False) -> NDArray:
     # error. Having already centred x, we can upscale it before downscaling it to avoid this issue. In case the
     # _magnitude should actually be 0, this won't make a difference to that.
     if _magnitude(x) == 0:
-        x *= 1000
+        x *= 1_000_000
     x /= _magnitude(x)
 
     return x

--- a/kymata/math/vector.py
+++ b/kymata/math/vector.py
@@ -11,11 +11,19 @@ def normalize(x: NDArray, inplace: bool = False) -> NDArray:
         x = np.copy(x)
 
     x -= np.mean(x, axis=-1, keepdims=True)
-    x /= np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
+
+    if _magnitude(x) == 0:
+        x *= 1000
+    x /= _magnitude(x)
+
     return x
 
 
-def get_stds(x, n):
+def _magnitude(x: NDArray) -> float:
+    return np.sqrt(np.sum(x**2, axis=-1, keepdims=True)).item()
+
+
+def get_stds(x: NDArray, n: int):
     """
     Get the stds (times sqrt(n)) to correct for normalisation difference between each set of n_samples
     """

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,16 @@
+import pytest
+from numpy import array, float16, errstate
+
+from kymata.entities.iterables import all_equal
+from kymata.math.vector import normalize
+
+
+@pytest.fixture
+def small_vector():
+    return array([0.0001237, 0.0001237, 0.0001237, 0.0001237, 0.0001237, 0.0001237,
+                  0.0001237, 0.0001237, 0.0001237, 0.0001237], dtype=float16)
+
+
+def test_normalize_small_vector(small_vector):
+    with errstate(divide='raise'):
+        normalize(small_vector)


### PR DESCRIPTION
- Fixes #340. 
- Fixes #343.
- Allows `kymata.math.vector.normalize` to optionally work in place, or return a copy, and updates its usages accordingly.
- Reverts #331 which was a failed attempt to solve the same gridsearch bug now highlighted by #340, and which is now unnecessary.