### PR TITLE
Ippm improvements

### DIFF
--- a/kymata/ippm/cluster.py
+++ b/kymata/ippm/cluster.py
@@ -6,6 +6,8 @@ from typing import List, Dict, Self, Optional
 
 from sklearn.mixture import GaussianMixture
 from sklearn.cluster import DBSCAN, MeanShift
+from sklearn.utils._testing import ignore_warnings
+from sklearn.exceptions import ConvergenceWarning
 
 import pandas as pd
 import numpy as np
@@ -185,6 +187,7 @@ class GMMClusterer(CustomClusterer):
             #)
         return self
 
+    @ignore_warnings(category=ConvergenceWarning)
     def _grid_search_for_optimal_number_of_clusters(
         self, df: pd.DataFrame
     ) -> GaussianMixture:
@@ -210,7 +213,8 @@ class GMMClusterer(CustomClusterer):
         optimal_penalised_loglikelihood = np.inf
         optimal_model = None
         for number_of_clusters in range(1, self._number_of_clusters_upper_bound):
-            if number_of_clusters > len(df):
+            if number_of_clusters > len(df) or len(df) == 1:
+                self.labels_ = [0 for _ in range(len(df))] # default label == 0.
                 break
 
             copy_of_df = deepcopy(df)

--- a/kymata/ippm/denoising_strategies.py
+++ b/kymata/ippm/denoising_strategies.py
@@ -210,7 +210,10 @@ class DenoisingStrategy(ABC):
                 Short text on normalisation for future reference.
                 https://www.kaggle.com/code/residentmario/l1-norms-versus-l2-norms
             """
-            normed_latency_and_mag = np.c_[normalize(df, axis=0), mags]
+            if self._should_cluster_only_latency:
+                normed_latency_and_mag = np.c_[normalize(df, axis=0), mags]
+            else:
+                normed_latency_and_mag = normalize(df, axis=0)
             df = pd.DataFrame(normed_latency_and_mag, columns=[LATENCY, MAGNITUDE])
         return df
 

--- a/kymata/ippm/denoising_strategies.py
+++ b/kymata/ippm/denoising_strategies.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import normalize
 
 from .constants import TIMEPOINTS, NUMBER_OF_HEXELS
 from .cluster import (
@@ -132,6 +131,8 @@ class DenoisingStrategy(ABC):
 
             spikes[func] = self._postprocess(spikes[func], denoised_time_series)
 
+            self._clusterer.labels_ = []  # reset clusterer labels between runs
+
         return spikes
 
     def _map_spikes_to_df(self, spikes: SpikeDict) -> pd.DataFrame:
@@ -199,9 +200,10 @@ class DenoisingStrategy(ABC):
         """
 
         def __extract_and_wrap_latency_dim(df_with_latency_col):
-            return np.reshape(df_with_latency_col[LATENCY], (-1, 1))
+            np_arr = np.reshape(df_with_latency_col[LATENCY], (-1, 1))
+            return pd.DataFrame(np_arr, columns=[LATENCY])
 
-        mags = list(df[MAGNITUDE])
+        df = deepcopy(df)
         if self._should_cluster_only_latency:
             df = __extract_and_wrap_latency_dim(df)
         if self._should_normalise:
@@ -211,10 +213,15 @@ class DenoisingStrategy(ABC):
                 https://www.kaggle.com/code/residentmario/l1-norms-versus-l2-norms
             """
             if self._should_cluster_only_latency:
-                normed_latency_and_mag = np.c_[normalize(df, axis=0), mags]
+                df = self._normalize(df, [LATENCY])
             else:
-                normed_latency_and_mag = normalize(df, axis=0)
-            df = pd.DataFrame(normed_latency_and_mag, columns=[LATENCY, MAGNITUDE])
+                df = self._normalize(df, [LATENCY, MAGNITUDE])
+        return df
+    
+    @staticmethod
+    def _normalize(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+        for col in cols:
+            df[col] = df[col] / df[col].sum()
         return df
 
     def _get_denoised_time_series(self, df: pd.DataFrame) -> list[tuple[float, float]]:

--- a/kymata/ippm/plot.py
+++ b/kymata/ippm/plot.py
@@ -76,7 +76,7 @@ def plot_ippm(
             end = graph[node].position
             pairs.append([(start[0], start[1]), (end[0], end[1])])
             edge_colors.append(node_colors[i])
-            label = __get_label(inc_edge)
+            label = __get_label(node)
             edge_labels.append(label)
             
         bsplines += _make_bspline_paths(pairs)

--- a/tests/test_ippm_denoising_strategies_integration_tests.py
+++ b/tests/test_ippm_denoising_strategies_integration_tests.py
@@ -176,6 +176,7 @@ def test_GMMStrategy_AllTrue_Fit_Successfully():
     random_seed = 40
     expected_denoised = deepcopy(noisy_test_hexels)
     expected_denoised["func1"].right_best_pairings = [
+        (176, 1e-50),
         (30, 1e-100),
         (199, 1e-90),
         (-75, 1e-75),

--- a/tests/test_ippm_denoising_strategies_unit_tests.py
+++ b/tests/test_ippm_denoising_strategies_unit_tests.py
@@ -5,7 +5,6 @@ from unittest.mock import patch, MagicMock
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
-import math
 
 from kymata.entities.constants import HEMI_RIGHT
 from kymata.ippm.data_tools import IPPMSpike
@@ -161,15 +160,10 @@ def test_DenoisingStrategy_UpdatePairings_Successfully():
 
 def test_DenoisingStrategy_Preprocess_Successfully():
     df = deepcopy(test_df_func2)
-    latencies_only_test_data_2 = map(lambda x: x[0], significant_test_data_func2)
-    sqrt_sum_squared_latencies = math.sqrt(
-        sum(map(lambda x: x**2, latencies_only_test_data_2))
-    )
-    normed_latencies = list(
-        map(lambda x: x[0] / sqrt_sum_squared_latencies, significant_test_data_func2)
-    )
+    latencies_only_test_data_2 = list(map(lambda x: x[0], significant_test_data_func2))
+    sum_latency = sum(latencies_only_test_data_2)
+    normed_latencies = [latency / sum_latency for latency in list(latencies_only_test_data_2)]
     expected_df = pd.DataFrame(normed_latencies, columns=[LATENCY])
-    expected_df[MAGNITUDE] = df[MAGNITUDE]
 
     strategy = DenoisingStrategy(
         HEMI_RIGHT, should_normalise=True, should_cluster_only_latency=True


### PR DESCRIPTION
This branch currently has:
- Updates plot.py to plot "node" rather than "inc_edge". The consequence is that it does not print the parent label.
- Normalization wasn't working before due to the incredibly small magnitude numbers and it was the l2 norm. I swapped it to the l1 norm since we want to scale to unit length to account for variance in each dimension. Essentially, l1 > l2 and sklearn normalizers suffered from numerical instability, so I created a manual self._normalise function. I verified through manual tests that the dataframes are normalised correctly, even if we are doing latency-focused clustering.
- Preprocessing was buggy since it modified the dataframe in-place. If we preprocess the df, we don't want to plot the processed data but the unnormalized data. This is why we need to copy it. It is trivial to recover the original data from the processed data since we don't shuffle the data after processing it, so the indexes are the same.
- Mute GMM convergence warning. 
- In GMM, if data is too small (1 row only or < n_clusters), we set it to a default value of 0.
- There was a bug where if a clustering fails in a transform (e.g., only 1 row of data for GMM), it doesn't update self.labels_. As a result, the subsequent transforms actually have incorrect labels (the labels from the previous run). Fixed this by resetting self.labels_ = [] after each fitting.
- Update relevant unit/integration tests.