### PR TITLE
Speed up loading .nkg files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ docs/_build/
 
 #.vscode settings
 .vscode
+
+# Stratch file
+scratch.py

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -217,7 +217,7 @@ class ExpressionSet(ABC):
         for block_name, block_data in data_blocks.items():
             if data_supplied_as_sequence:
                 # Build DataArray by concatenating sequence
-                data_array: DataArray = concat_dataarrays(
+                data_array: DataArray = _concat_dataarrays(
                     [
                         DataArray(
                             self._init_prep_data(function_data),
@@ -575,8 +575,8 @@ class HexelExpressionSet(ExpressionSet):
             hexels_lh=self.hexels_left,
             hexels_rh=self.hexels_right,
             latencies=self.latencies,
-            data_lh=concat_dataarrays([self.left, other.left]).data,
-            data_rh=concat_dataarrays([self.right, other.right]).data,
+            data_lh=_concat_dataarrays([self.left, other.left]).data,
+            data_rh=_concat_dataarrays([self.right, other.right]).data,
         )
 
     def __eq__(self, other: HexelExpressionSet) -> bool:
@@ -681,7 +681,7 @@ class SensorExpressionSet(ExpressionSet):
             functions=self.functions + other.functions,
             sensors=self.sensors,
             latencies=self.latencies,
-            data=concat_dataarrays([self.scalp, other.scalp]).data,
+            data=_concat_dataarrays([self.scalp, other.scalp]).data,
         )
 
     def __getitem__(self, functions: str | Sequence[str]) -> SensorExpressionSet:
@@ -730,7 +730,7 @@ def combine(expression_sets: Sequence[T_ExpressionSetSubclass]) -> T_ExpressionS
     return expression_sets[0] + combine(expression_sets[1:])
 
 
-def concat_dataarrays(arrays: Sequence[DataArray]) -> DataArray:
+def _concat_dataarrays(arrays: Sequence[DataArray]) -> DataArray:
     return concat(
         arrays,
         dim=DIM_FUNCTION,

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -291,7 +291,7 @@ class ExpressionSet(ABC):
         elif not isinstance(data, SparseArray):
             raise NotImplementedError()
 
-        if data.ndim <= 2:
+        if data.ndim < 3:
             data = expand_dims(data, axis=2)
         return data
 

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -163,6 +163,9 @@ class ExpressionSet(ABC):
                         raise ValueError(f"Latencies mismatch for {function_name}: "
                                          f"{len(latencies)} latencies versus data shape {data.shape} "
                                          f"({block_name})")
+                    if not len(functions) == len(block_data):
+                        raise ValueError(f"Functions mismatch for {block_name}: "
+                                         f"{len(functions)} functions but only {len(block_data)} data blocks")
                     if len(data.shape) > 3:
                         raise ValueError(f"Too many dimensions in data for {function_name}: "
                                          f"shape={data.shape} "
@@ -186,7 +189,7 @@ class ExpressionSet(ABC):
                                      f"({block_name})")
                 if len(block_data.shape) == 3 and len(functions) != block_data.shape[2]:
                     raise ValueError(f"Functions mismatch: "
-                                     f"{len(functions)} functions verus data shape {block_data.shape} "
+                                     f"{len(functions)} functions versus data shape {block_data.shape} "
                                      f"({block_name})")
 
         ############################################

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -74,6 +74,9 @@ class ExpressionSet(ABC):
                 names to data arrays. E.g., in the case there are three functions in a hexel setting:
                 ```
                     {
+                                  # each array is (channel, latency)-shaped
+                                  # and there's one for each function
+                                  # ↓
                         "left":  [array(...), array(...), array(...)],
                         "right": [array(...), array(...), array(...)],
                     }
@@ -81,13 +84,22 @@ class ExpressionSet(ABC):
                 or in a sensor setting:
                 ```
                     {
-                        "scalp": [array(), array(), array()],
+                        "scalp": [array(...), array(...), array(...)],
                     }
                 ```
+                (and where `array(...)` can be a numpy array or a sparse array).
                 In this format, all data arrays should be the same size.
 
                 In the second (more performant) format, `data_blocks` contains a single data array whose `function`
-                dimensions can be concatenated to achieve the desired resultant data block.
+                dimensions can be concatenated to achieve the desired resultant data block. E.g.
+                ```
+                    {
+                                  # each array is (channel, latency, function)-shaped
+                                  # ↓
+                        "left":  array(...),
+                        "right": array(...),
+                    }
+                ```
             channel_coord_name (str): Name of the channel coordinate.
             channel_coord_dtype: Data type of the channel coordinate.
             channel_coord_values (dict[str, Sequence]): Dictionary mapping block names to channel coordinate values.

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -163,6 +163,14 @@ class ExpressionSet(ABC):
                         raise ValueError(f"Latencies mismatch for {function_name}: "
                                          f"{len(latencies)} latencies versus data shape {data.shape} "
                                          f"({block_name})")
+                    if len(data.shape) > 3:
+                        raise ValueError(f"Too many dimensions in data for {function_name}: "
+                                         f"shape={data.shape} "
+                                         f"({block_name})")
+                    if len(data.shape) == 3 and data.shape[2] != 1:
+                        raise ValueError(f"Too many dimensions in data for {function_name}: "
+                                         f"shape={data.shape} "
+                                         f"({block_name})")
             else:
                 if len(channels[block_name]) != block_data.shape[0]:
                     raise ValueError(f"{channel_coord_name} mismatch: "
@@ -172,7 +180,11 @@ class ExpressionSet(ABC):
                     raise ValueError(f"Latencies mismatch: "
                                      f"{len(latencies)} latencies versus data shape {block_data.shape} "
                                      f"({block_name})")
-                if len(functions) != block_data.shape[2]:
+                if len(block_data.shape) > 3:
+                    raise ValueError(f"Too many dimensions in data: "
+                                     f"shape={block_data.shape} "
+                                     f"({block_name})")
+                if len(block_data.shape) == 3 and len(functions) != block_data.shape[2]:
                     raise ValueError(f"Functions mismatch: "
                                      f"{len(functions)} functions verus data shape {block_data.shape} "
                                      f"({block_name})")

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -107,12 +107,7 @@ class ExpressionSet(ABC):
                 data_blocks[bn] = [data_blocks[bn]]
 
         self._validate_functions_no_duplicates(functions)
-
-        for data in data_blocks.values():
-            assert len(functions) == len(data), _length_mismatch_message
-        assert all_equal(
-            [arr.shape[1] for arrs in data_blocks.values() for arr in arrs]
-        ), "Not all input data blocks have the same"
+        assert all_equal([arr.shape[1] for arrs in data_blocks.values() for arr in arrs]), "Not all input data blocks have the same"
 
         # Channels can vary between blocks (e.g. different numbers of vertices for each hemisphere).
         # But latencies and functions do not
@@ -129,46 +124,64 @@ class ExpressionSet(ABC):
         # i.e. a dict mapping block names to a DataArray containing data for all functions
         self._data: dict[str, DataArray] = dict()
         nan_warning_sent = False
-        for block_name, data_for_functions in data_blocks.items():
-            for function_name, data in zip(functions, data_for_functions):
-                assert (
-                    len(channels[block_name]) == data.shape[0]
-                ), f"{channel_coord_name} mismatch for {function_name}: {len(channels)} {channel_coord_name} versus data shape {data.shape} ({block_name})"
-                assert (
-                    len(latencies) == data.shape[1]
-                ), f"Latencies mismatch for {function_name}: {len(latencies)} latencies versus data shape {data.shape}"
-            data_array: DataArray = concat(
-                (
-                    DataArray(
-                        self._init_prep_data(d),
-                        coords={
-                            channel_coord_name: channels[block_name],
-                            DIM_LATENCY: latencies,
-                            DIM_FUNCTION: [function],
-                        },
-                    )
-                    for function, d in zip(functions, data_for_functions)
-                ),
-                dim=DIM_FUNCTION,
-                data_vars="all",  # Required by concat of DataArrays
-            )
+        for data in data_blocks.values():
+            if len(functions) == len(data):
+                for block_name, data_for_functions in data_blocks.items():
+                    for function_name, data in zip(functions, data_for_functions):
+                        assert len(channels[block_name]) == data.shape[0], f"{channel_coord_name} mismatch for {function_name}: {len(channels)} {channel_coord_name} versus data shape {data.shape} ({block_name})"
+                        assert len(latencies) == data.shape[1], f"Latencies mismatch for {function_name}: {len(latencies)} latencies versus data shape {data.shape}"
+                    data_array: DataArray = concat(
+                        (
+                            DataArray(self._init_prep_data(d),
+                                    coords={
+                                        channel_coord_name: channels[block_name],
+                                        DIM_LATENCY: latencies,
+                                        DIM_FUNCTION: [function]
+                                    })
+                            for function, d in zip(functions, data_for_functions)
+                        ),
+                        dim=DIM_FUNCTION,
+                        data_vars="all",  # Required by concat of DataArrays
+                        )
 
-            # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on the medial
-            # wall. We can ignore these nans by setting the values to p=1, but because it's not typically expected we
-            # warn the user about it.
-            if data_array.isnull().any():
-                data_array = data_array.fillna(value=0)  # logp = 0 => p = 1
-                if not nan_warning_sent:  # Only want to send the warning once, even if there are multiple data blocks with nans.
-                    warn(
-                        "Supplied data contained nans. These will be replaced by p = 1 values."
-                    )
-                    nan_warning_sent = True
+                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on the medial
+                    # wall. We can ignore these nans by setting the values to p=1, but because it's not typically expected we
+                    # warn the user about it.
+                    if data_array.isnull().any():
+                        data_array = data_array.fillna(value=0)  # logp = 0 => p = 1
+                        if not nan_warning_sent:  # Only want to send the warning once, even if there are multiple data blocks with nans.
+                            warn("Supplied data contained nans. These will be replaced by p = 1 values.")
+                            nan_warning_sent = True
 
-            assert data_array.dims == self._dims
-            assert set(data_array.coords.keys()) == set(self._dims)
-            assert array_equal(data_array.coords[DIM_FUNCTION].values, functions)
+                    assert data_array.dims == self._dims
+                    assert set(data_array.coords.keys()) == set(self._dims)
+                    assert array_equal(data_array.coords[DIM_FUNCTION].values, functions)
 
-            self._data[block_name] = data_array
+                    self._data[block_name] = data_array
+
+            else:
+                for block_name, data_for_functions in data_blocks.items():
+                    data_array = DataArray(data_for_functions,
+                                    coords={
+                                        channel_coord_name: channels[block_name],
+                                        DIM_LATENCY: latencies,
+                                        DIM_FUNCTION: functions
+                                    })
+
+                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on the medial
+                    # wall. We can ignore these nans by setting the values to p=1, but because it's not typically expected we
+                    # warn the user about it.
+                    if data_array.isnull().any():
+                        data_array = data_array.fillna(value=0)  # logp = 0 => p = 1
+                        if not nan_warning_sent:  # Only want to send the warning once, even if there are multiple data blocks with nans.
+                            warn("Supplied data contained nans. These will be replaced by p = 1 values.")
+                            nan_warning_sent = True
+
+                    assert data_array.dims == self._dims
+                    assert set(data_array.coords.keys()) == set(self._dims)
+                    assert array_equal(data_array.coords[DIM_FUNCTION].values, functions)
+
+                    self._data[block_name] = data_array
 
     def _validate_functions_no_duplicates(self, functions):
         if not len(functions) == len(set(functions)):

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -153,12 +153,13 @@ class ExpressionSet(ABC):
                         data_vars="all",  # Required by concat of DataArrays
                         )
 
-                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on the medial
-                    # wall. We can ignore these nans by setting the values to p=1, but because it's not typically expected we
-                    # warn the user about it.
+                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on
+                    # the medial wall. We can ignore these nans by setting the values to p=1, but because it's not
+                    # typically expected we warn the user about it.
                     if data_array.isnull().any():
                         data_array = data_array.fillna(value=0)  # logp = 0 => p = 1
-                        if not nan_warning_sent:  # Only want to send the warning once, even if there are multiple data blocks with nans.
+                        # Only want to send the warning once, even if there are multiple data blocks with nans.
+                        if not nan_warning_sent:
                             warn("Supplied data contained nans. These will be replaced by p = 1 values.")
                             nan_warning_sent = True
 
@@ -192,12 +193,13 @@ class ExpressionSet(ABC):
                             data_vars="all",  # Required by concat of DataArrays
                             )
 
-                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on the medial
-                    # wall. We can ignore these nans by setting the values to p=1, but because it's not typically expected we
-                    # warn the user about it.
+                    # Sometimes the data can contain nans, for example if the MEG hexel currents were set to nan on
+                    # the medial wall. We can ignore these nans by setting the values to p=1, but because it's not
+                    # typically expected we warn the user about it.
                     if data_array.isnull().any():
                         data_array = data_array.fillna(value=0)  # logp = 0 => p = 1
-                        if not nan_warning_sent:  # Only want to send the warning once, even if there are multiple data blocks with nans.
+                        # Only want to send the warning once, even if there are multiple data blocks with nans.
+                        if not nan_warning_sent:
                             warn("Supplied data contained nans. These will be replaced by p = 1 values.")
                             nan_warning_sent = True
 

--- a/kymata/entities/iterables.py
+++ b/kymata/entities/iterables.py
@@ -3,13 +3,13 @@ Functions for dealing with iterables.
 """
 
 from itertools import groupby
-from typing import Sequence
+from typing import Collection
 
 from numpy import ndarray
 from numpy.typing import NDArray
 
 
-def all_equal(sequence: Sequence) -> bool:
+def all_equal(sequence: Collection) -> bool:
     """
     Check if all elements in the sequence are the same.
 
@@ -18,7 +18,7 @@ def all_equal(sequence: Sequence) -> bool:
     with equality checks.
 
     Args:
-        sequence (Sequence): A sequence of elements to be checked for equality. This can be any iterable
+        sequence (Collection): A sequence of elements to be checked for equality. This can be any iterable
                              including lists, tuples, or numpy arrays.
 
     Returns:
@@ -31,6 +31,7 @@ def all_equal(sequence: Sequence) -> bool:
         - For numpy arrays, the function ensures element-wise comparison using the `.all()` method to handle
           array equality correctly.
     """
+    sequence = list(sequence)
 
     if len(sequence) == 0:
         # universal quantification over empty set is always true

--- a/kymata/entities/sparse_data.py
+++ b/kymata/entities/sparse_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from numpy import nanmin, greater
+from numpy import nanmin, greater, expand_dims as np_expand_dims
 from numpy.typing import NDArray
 import sparse
 from xarray import DataArray
@@ -30,14 +30,18 @@ def expand_dims(x: sparse.COO, axis=-1) -> sparse.COO:
 
 def sparsify_log_pmatrix(log_pmatrix: NDArray) -> sparse.COO:
     """
-    Converts a channel-x-latency data matrix containing log p-values into a sparse matrix
-    only storing the minimum (over latencies) log p-value for each channel.
+    Converts a (channel, latency, function)-shaped data matrix containing log p-values into a sparse matrix only storing
+    the minimum (over latencies) log p-value for each channel, for each function.
     """
     fill_value = 0.0
-    channel_min = nanmin(log_pmatrix, axis=1)
-    channel_min = expand_dims(channel_min, axis=2)
-    # Minimum value over all latencies for this channel
-    log_pmatrix[greater(log_pmatrix, channel_min)] = fill_value
+    # Iterate over the third dimension
+    if log_pmatrix.ndim < 3:
+        log_pmatrix = np_expand_dims(log_pmatrix, axis=2)
+    for depth in range(log_pmatrix.shape[2]):
+        channel_min = nanmin(log_pmatrix[:, :, depth], axis=1)
+        channel_min = expand_dims(channel_min, axis=1)
+        # Minimum value over all latencies for this channel at this depth
+        log_pmatrix[:, :, depth][greater(log_pmatrix[:, :, depth], channel_min)] = fill_value
     return sparse.COO(log_pmatrix, fill_value=fill_value)
 
 

--- a/kymata/io/nkg.py
+++ b/kymata/io/nkg.py
@@ -144,10 +144,7 @@ def load_expression_set(
             functions=data_dict[_Keys.functions],
             sensors=[SensorDType(c) for c in data_dict[_Keys.channels][BLOCK_SCALP]],
             latencies=data_dict[_Keys.latencies],
-            data=[
-                data_dict[_Keys.data][BLOCK_SCALP][:, :, i]
-                for i in range(len(data_dict[_Keys.functions]))
-            ],
+            data=data_dict[_Keys.data][BLOCK_SCALP],
         )
 
 

--- a/kymata/io/nkg.py
+++ b/kymata/io/nkg.py
@@ -130,14 +130,8 @@ def load_expression_set(
             hexels_lh=[HexelDType(c) for c in data_dict[_Keys.channels][BLOCK_LEFT]],
             hexels_rh=[HexelDType(c) for c in data_dict[_Keys.channels][BLOCK_RIGHT]],
             latencies=data_dict[_Keys.latencies],
-            data_lh=[
-                data_dict[_Keys.data][BLOCK_LEFT][:, :, i]
-                for i in range(len(data_dict[_Keys.functions]))
-            ],
-            data_rh=[
-                data_dict[_Keys.data][BLOCK_RIGHT][:, :, i]
-                for i in range(len(data_dict[_Keys.functions]))
-            ],
+            data_lh=data_dict[_Keys.data][BLOCK_LEFT],
+            data_rh=data_dict[_Keys.data][BLOCK_RIGHT],
         )
     elif type_identifier == _ExpressionSetTypeIdentifier.sensor:
         return SensorExpressionSet(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -380,7 +380,7 @@ def test_ses_validation_input_lengths_two_functions_one_dataset():
         )
 
 
-def test_ses_validation_input_lengths_two_functions_two_datasets():
+def test_ses_validation_input_lengths_two_functions_two_datasets_sequence():
     SensorExpressionSet(
         functions=["first", "second"],
         sensors=list("abcde"),
@@ -389,13 +389,32 @@ def test_ses_validation_input_lengths_two_functions_two_datasets():
     )
 
 
-def test_ses_validation_input_lengths_two_functions_three_datasets():
+def test_ses_validation_input_lengths_two_functions_two_datasets_contiguous():
+    SensorExpressionSet(
+        functions=["first", "second"],
+        sensors=list("abcde"),
+        latencies=range(10),
+        data=np.random.randn(5, 10, 2),
+    )
+
+
+def test_ses_validation_input_lengths_two_functions_three_datasets_sequence():
     with pytest.raises(ValueError):
         SensorExpressionSet(
             functions=["first", "second"],
             sensors=list("abcde"),
             latencies=range(10),
             data=[np.random.randn(5, 10) for _ in range(3)],
+        )
+
+
+def test_ses_validation_input_lengths_two_functions_three_datasets_contiguous():
+    with pytest.raises(ValueError):
+        SensorExpressionSet(
+            functions=["first", "second"],
+            sensors=list("abcde"),
+            latencies=range(10),
+            data=np.random.randn(5, 10, 3),
         )
 
 
@@ -411,7 +430,7 @@ def test_hes_validation_input_lengths_two_functions_one_dataset():
         )
 
 
-def test_hes_validation_input_lengths_two_functions_two_datasets():
+def test_hes_validation_input_lengths_two_functions_two_datasets_sequence():
     HexelExpressionSet(
         functions=["first", "second"],
         hexels_lh=range(5),
@@ -422,7 +441,18 @@ def test_hes_validation_input_lengths_two_functions_two_datasets():
     )
 
 
-def test_hes_validation_input_lengths_two_functions_three_datasets():
+def test_hes_validation_input_lengths_two_functions_two_datasets_contiguous():
+    HexelExpressionSet(
+        functions=["first", "second"],
+        hexels_lh=range(5),
+        hexels_rh=range(5),
+        latencies=range(10),
+        data_lh=np.random.randn(5, 10, 2),
+        data_rh=np.random.randn(5, 10, 2),
+    )
+
+
+def test_hes_validation_input_lengths_two_functions_three_datasets_sequence():
     with pytest.raises(ValueError):
         HexelExpressionSet(
             functions=["first", "second"],
@@ -431,6 +461,18 @@ def test_hes_validation_input_lengths_two_functions_three_datasets():
             latencies=range(10),
             data_lh=[np.random.randn(5, 10) for _ in range(3)],
             data_rh=[np.random.randn(5, 10) for _ in range(3)],
+        )
+
+
+def test_hes_validation_input_lengths_two_functions_three_datasets_contiguous():
+    with pytest.raises(ValueError):
+        HexelExpressionSet(
+            functions=["first", "second"],
+            hexels_lh=range(5),
+            hexels_rh=range(5),
+            latencies=range(10),
+            data_lh=np.random.randn(5, 10, 3),
+            data_rh=np.random.randn(5, 10, 3),
         )
 
 
@@ -455,7 +497,7 @@ def test_hes_validation_input_mismatched_blocks_concordent_channels():
     )
 
 
-def test_hes_validation_input_mismatched_blocks_concordent_channels_two_functions():
+def test_hes_validation_input_mismatched_blocks_concordent_channels_two_functions_sequence():
     HexelExpressionSet(
         functions=["first", "second"],
         hexels_lh=range(5),
@@ -463,6 +505,17 @@ def test_hes_validation_input_mismatched_blocks_concordent_channels_two_function
         latencies=range(10),
         data_lh=[np.random.randn(5, 10), np.random.randn(5, 10)],
         data_rh=[np.random.randn(6, 10), np.random.randn(6, 10)],
+    )
+
+
+def test_hes_validation_input_mismatched_blocks_concordent_channels_two_functions_contiguous():
+    HexelExpressionSet(
+        functions=["first", "second"],
+        hexels_lh=range(5),
+        hexels_rh=range(6),
+        latencies=range(10),
+        data_lh=np.random.randn(5, 10, 2),
+        data_rh=np.random.randn(6, 10, 2),
     )
 
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -398,6 +398,16 @@ def test_ses_validation_input_lengths_two_functions_two_datasets_contiguous():
     )
 
 
+def test_ses_validation_input_lengths_one_function_two_datasets_contiguous():
+    with pytest.raises(ValueError):
+        SensorExpressionSet(
+            functions=["first"],
+            sensors=list("abcde"),
+            latencies=range(10),
+            data=np.random.randn(5, 10, 2),
+        )
+
+
 def test_ses_validation_input_lengths_two_functions_three_datasets_sequence():
     with pytest.raises(ValueError):
         SensorExpressionSet(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -371,7 +371,7 @@ def test_ses_best_function_with_one_channel_all_nans():
 
 
 def test_ses_validation_input_lengths_two_functions_one_dataset():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         SensorExpressionSet(
             functions=["first", "second"],
             sensors=list("abcde"),
@@ -390,7 +390,7 @@ def test_ses_validation_input_lengths_two_functions_two_datasets():
 
 
 def test_ses_validation_input_lengths_two_functions_three_datasets():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         SensorExpressionSet(
             functions=["first", "second"],
             sensors=list("abcde"),
@@ -400,7 +400,7 @@ def test_ses_validation_input_lengths_two_functions_three_datasets():
 
 
 def test_hes_validation_input_lengths_two_functions_one_dataset():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         HexelExpressionSet(
             functions=["first", "second"],
             hexels_lh=range(5),
@@ -423,7 +423,7 @@ def test_hes_validation_input_lengths_two_functions_two_datasets():
 
 
 def test_hes_validation_input_lengths_two_functions_three_datasets():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         HexelExpressionSet(
             functions=["first", "second"],
             hexels_lh=range(5),
@@ -467,7 +467,7 @@ def test_hes_validation_input_mismatched_blocks_concordent_channels_two_function
 
 
 def test_hes_validation_input_mismatched_blocks_discordent_channels():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         HexelExpressionSet(
             functions="function",
             hexels_lh=range(5),
@@ -479,7 +479,7 @@ def test_hes_validation_input_mismatched_blocks_discordent_channels():
 
 
 def test_hes_validation_mixmatched_latencies_between_functions():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         HexelExpressionSet(
             functions=["first", "second"],
             hexels_lh=range(5),
@@ -491,7 +491,7 @@ def test_hes_validation_mixmatched_latencies_between_functions():
 
 
 def test_hes_validation_mixmatched_hexels_between_functions():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         HexelExpressionSet(
             functions=["first", "second"],
             hexels_lh=range(5),


### PR DESCRIPTION
## Fixes #271 

Loading over 5k functions from a .nkg file goes from **49 functions/second** to ***~928~ 1,331 functions/second****!

Thanks to @young-x-skyee for most of the work on this — I just cherry-picked commits from the `kymata-language` branch, and tidied up the code a little, and added/fixed tests

## Main changes

- [x] New permitted and more performant argument format for `ExpressionSet.__init__()`.
- [x] Update `load_nkg` to use new format to benefit from the speedups
- [x] Documentation for new format.
  - Added to `ExpressionSet.__init__()` docstring.
- [x] Tests for new argument format.
- [x] Refactored `combine()` to use new format and benefit from the speedups.
- [x] Refactored `ExpressionSet.__add__()` to use the new format and benefit from the speedups.



*: on my laptop