### PR TITLE
Some ultimately ineffectual refactoring which is still worth doing

### DIFF
--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -551,16 +551,14 @@ class HexelExpressionSet(ExpressionSet):
         )
 
     def __copy__(self):
-        data_left: NDArray = self._data[BLOCK_LEFT].data.todense()
-        data_right: NDArray = self._data[BLOCK_RIGHT].data.todense()
         return HexelExpressionSet(
             functions=self.functions.copy(),
             hexels_lh=self.hexels_left.copy(),
             hexels_rh=self.hexels_right.copy(),
             latencies=self.latencies.copy(),
             # Slice by function
-            data_lh=[data_left[:, :, i].copy() for i in range(data_left.shape[2])],
-            data_rh=[data_right[:, :, i].copy() for i in range(data_right.shape[2])],
+            data_lh=self._data[BLOCK_LEFT].data.copy(),
+            data_rh=self._data[BLOCK_RIGHT].data.copy(),
         )
 
     def __add__(self, other: HexelExpressionSet) -> HexelExpressionSet:
@@ -661,13 +659,11 @@ class SensorExpressionSet(ExpressionSet):
         return True
 
     def __copy__(self):
-        data: NDArray = self._data[BLOCK_SCALP].data.todense()
         return SensorExpressionSet(
             functions=self.functions.copy(),
             sensors=self.sensors.copy(),
             latencies=self.latencies.copy(),
-            # Slice by function
-            data=[data[:, :, i].copy() for i in range(data.shape[2])],
+            data=self._data[BLOCK_SCALP].data.copy(),
         )
 
     def __add__(self, other: SensorExpressionSet) -> SensorExpressionSet:

--- a/kymata/entities/expression.py
+++ b/kymata/entities/expression.py
@@ -532,22 +532,20 @@ class HexelExpressionSet(ExpressionSet):
         # Allow indexing by a single function
         if isinstance(functions, str):
             functions = [functions]
+        # Get indices of sliced functions within total function list
+        function_idxs = []
         for f in functions:
-            if f not in self.functions:
+            try:
+                function_idxs.append(self.functions.index(f))
+            except ValueError:
                 raise KeyError(f)
         return HexelExpressionSet(
             functions=functions,
             hexels_lh=self.hexels_left,
             hexels_rh=self.hexels_right,
             latencies=self.latencies,
-            data_lh=[
-                self._data[BLOCK_LEFT].sel({DIM_FUNCTION: function}).data
-                for function in functions
-            ],
-            data_rh=[
-                self._data[BLOCK_RIGHT].sel({DIM_FUNCTION: function}).data
-                for function in functions
-            ],
+            data_lh=self._data[BLOCK_LEFT].data[:, :, function_idxs],
+            data_rh=self._data[BLOCK_RIGHT].data[:, :, function_idxs],
         )
 
     def __copy__(self):
@@ -688,17 +686,19 @@ class SensorExpressionSet(ExpressionSet):
         # Allow indexing by a single function
         if isinstance(functions, str):
             functions = [functions]
+        # Get indices of sliced functions within total function list
+        function_idxs = []
         for f in functions:
-            if f not in self.functions:
+            try:
+                function_idxs.append(self.functions.index(f))
+            except ValueError:
                 raise KeyError(f)
         return SensorExpressionSet(
             functions=functions,
             sensors=self.sensors,
             latencies=self.latencies,
-            data=[
-                self._data[BLOCK_SCALP].sel({DIM_FUNCTION: function}).data
-                for function in functions
-            ],
+            # Slice data by requested functions
+            data=self._data[BLOCK_SCALP].data[:, :, function_idxs],
         )
 
     def best_functions(self) -> DataFrame:

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -522,6 +522,9 @@ def expression_plot(
 
     fig.subplots_adjust(**mosaic.subplots_adjust_kwargs)
 
+    # Turn off autoscaling to make plotting faster, and since we manually set the axes scale later
+    pyplot.autoscale(False)
+
     custom_handles = []
     custom_labels = []
     data_x_min, data_x_max = np.Inf, -np.Inf


### PR DESCRIPTION
This was originally intended to address #354, but in fact it doesn't. See the issue for why. Nevertheless it's worth getting into main for code cleanliness's sake.

## The change

- Iterating through functions one at a time used the slow `.sel` methods inside a list comprehension. Replace this with the new argument interface from #374.
- Also speed up `ExpressionSet.__copy__` and `ExpressinoSet.__getitem__`.