### PR TITLE
Fixes #142: hardcoding of project directory in submit_gridsearch.sh

### DIFF
--- a/submit_gridsearch.sh
+++ b/submit_gridsearch.sh
@@ -23,8 +23,7 @@ apptainer exec \
   -B /imaging/projects/cbu/kymata/ \
   /imaging/local/software/singularity_images/python/python_3.11.7-slim.sif \
   bash -c \
-    " cd /imaging/projects/cbu/kymata/analyses/andy/kymata-core/ ; \
-      export VENV_PATH=~/poetry/ ; \
+    " export VENV_PATH=~/poetry/ ; \
       \$VENV_PATH/bin/poetry run python -m kymata.invokers.run_gridsearch \
         --config dataset4.yaml \
         --input-stream auditory \


### PR DESCRIPTION
Very simple fix for #142: just removes the line:
```
cd /imaging/projects/cbu/kymata/analyses/andy/kymata-core/ ;
```
altogether - the script still runs fine without it. I was under the impression that SLURM opened up in ~/home, but that doesn't seem to be true.