### PR TITLE
Temp fix for the float128 MacOS bug. Main fix on another branch

### DIFF
--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -543,7 +543,7 @@ def expression_plot(
 
     sidak_corrected_alpha = 1 - (
         (1 - alpha)
-        ** np.float128(1 / (2 * len(expression_set.latencies) * n_channels * len(show_only)))
+        ** np.longdouble(1 / (2 * len(expression_set.latencies) * n_channels * len(show_only)))
     )
 
     sidak_corrected_alpha = p_to_logp(sidak_corrected_alpha)


### PR DESCRIPTION
Fixes #421.
This would already have been fixed by #391, but it causes a persistent error on MacOS so I'm doing a quick fix to go into `main` now.