### PR TITLE
Minimap works with huge numbers of transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ docs/_build/
 .vscode
 
 # Stratch file
-scratch.py
+scratch.*

--- a/kymata/entities/iterables.py
+++ b/kymata/entities/iterables.py
@@ -55,3 +55,16 @@ def all_equal(sequence: Collection) -> bool:
     else:
         g = groupby(sequence)
         return next(g, True) and not next(g, False)
+
+
+def interleave(*lists) -> list:
+    """
+    Given some lists, returns a list of interleaved entries from list1, list2, list3, etc.
+
+    If the lists are of unequal length, stops after the length of the shortest list.
+    """
+    return [
+        val
+        for tup in zip(*lists)
+        for val in tup
+    ]

--- a/kymata/plot/color.py
+++ b/kymata/plot/color.py
@@ -1,5 +1,5 @@
-from matplotlib.colors import to_rgb, to_hex
-from numpy import linspace
+from matplotlib.colors import to_rgb, to_hex, ListedColormap
+from numpy import linspace, round as np_round
 
 
 def gradient_color_dict(transforms: list[str], start_color, stop_color) -> dict[str, str]:
@@ -61,3 +61,26 @@ def constant_color_dict(transforms: list[str], color) -> dict[str, str]:
     The returned dictionary is compatible with color specifications for expression plots.
     """
     return gradient_color_dict(transforms, color, color)
+
+
+class DiscreteListedColormap(ListedColormap):
+    """Like ListedColormap, but without interpolation between values."""
+    def __init__(self, colors: list, name = 'from_list', N = None, scale01: bool = False):
+        """
+
+        Args:
+            colors:
+            name:
+            N:
+            scale01 (bool): True if the values will be supplied to the colormap in the range [0, 1] instead of the range
+                [0, N-1].
+        """
+        self.scale01: bool = scale01
+        super().__init__(colors=colors, name=name, N=N)
+
+    def __call__(self, X, *args, **kwargs):
+        if self.scale01:
+            # Values are supplied between 0 and 1, so map them up to their corresponding index (or close to it)
+            X *= self.N
+        rounded = np_round(X).astype(int)
+        return super().__call__(X=rounded, *args, **kwargs)

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -91,12 +91,12 @@ def _minimap_mosaic(
         }
     elif minimap_option.lower() == "large":
         width_ratios = None
-        height_ratios = [4, 1, 1]
+        height_ratios = [6, 1, 1]
         subplots_adjust = {
             "hspace": 0,
-            "wspace": 0.25,
-            "left": 0.02,
-            "right": 0.8,
+            "wspace": 0.1,
+            "left": 0.08,
+            "right": 0.92,
         }
     else:
         raise NotImplementedError()

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -318,24 +318,13 @@ def _plot_minimap_hexel(
     fsaverage = FSAverageDataset(download=True)
     os.environ["SUBJECTS_DIR"] = str(fsaverage.path)
 
-    # Transforms which aren't being shown need to be padded into the colormap, for indexing purposes, but should show up
-    # as transparent
-    colors = colors.copy()
-    for transform in expression_set.transforms:
-        if transform not in show_transforms:
-            colors[transform] = transparent
+    colormap = _get_segmented_colormap_for_minimap(colors, expression_set, show_transforms)
 
-    # segment at index 0 will map to transparent
-    # segment at index i will map to transform of index i-1
-    colormap = LinearSegmentedColormap.from_list(
-        "custom",
-        # Insert transparent for index 0
-        colors=[transparent] + [colors[f] for f in expression_set.transforms],
-        # +1 for the transparency
-        N=len(expression_set.transforms) + 1,
-    )
     data_left, data_right = _hexel_minimap_data(
-        expression_set, alpha_logp=alpha_logp, show_transforms=show_transforms, minimap_latency_range=minimap_latency_range
+        expression_set,
+        alpha_logp=alpha_logp,
+        show_transforms=show_transforms,
+        minimap_latency_range=minimap_latency_range
     )
     stc = SourceEstimate(
         data=np.concatenate([data_left, data_right]),
@@ -374,6 +363,25 @@ def _plot_minimap_hexel(
     rh_minimap_axis.imshow(rh_brain.screenshot())
     hide_axes(rh_minimap_axis)
     pyplot.close(rh_brain_fig)
+
+
+def _get_segmented_colormap_for_minimap(colors, expression_set: ExpressionSet, show_transforms: list[str]):
+    # Transforms which aren't being shown need to be padded into the colormap, for indexing purposes, but should show up
+    # as transparent
+    colors = colors.copy()
+    for transform in expression_set.transforms:
+        if transform not in show_transforms:
+            colors[transform] = transparent
+    # segment at index 0 will map to transparent
+    # segment at index i will map to transform of index i-1
+    colormap = LinearSegmentedColormap.from_list(
+        "custom",
+        # Insert transparent for index 0
+        colors=[transparent] + [colors[f] for f in expression_set.transforms],
+        # +1 for the transparency
+        N=len(expression_set.transforms) + 1,
+    )
+    return colormap
 
 
 def hide_axes(axes: pyplot.Axes):

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -355,7 +355,7 @@ def _plot_minimap_hexel(
         clim=dict(
             kind="value",
             # There are two colormap entries for each transform: the transform itself and the interleaved transparency
-            lims=[0, len(show_transforms), len(show_transforms) * 2],
+            lims=[0, len(show_transforms) * smoothing_steps / 2, len(show_transforms) * smoothing_steps],
         ),
     )
     # Override plot kwargs with those passed

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -543,7 +543,7 @@ def expression_plot(
 
     sidak_corrected_alpha = 1 - (
         (1 - alpha)
-        ** np.float128(1 / (2 * len(expression_set.latencies) * n_channels * len(show_only)))
+        ** np.longdouble(1 / (2 * len(expression_set.latencies) * n_channels * len(show_only)))
     )
 
     sidak_corrected_alpha = p_to_logp(sidak_corrected_alpha)

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -402,7 +402,7 @@ def _get_segmented_colormap_for_cortical_minimap(colors: dict[str, Any],
 
     """
     if smoothing_steps < 0:
-        raise ValueError(f"smoothing_steps must be non-negative")
+        raise ValueError("smoothing_steps must be non-negative")
 
     base_colours = [colors[f] for f in show_transforms]  # Not including transparent
     transparent_copy = len(base_colours) * [transparent]

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -344,6 +344,7 @@ def _plot_minimap_hexel(
         views=view,
         colormap=colormap,
         smoothing_steps=2,
+        cortex=dict(colormap="Greys", vmin=-3, vmax=6),
         background="white",
         spacing="ico5",
         time_viewer=False,

--- a/kymata/plot/plot.py
+++ b/kymata/plot/plot.py
@@ -309,6 +309,7 @@ def _plot_minimap_hexel(
     surface: str,
     colors: dict[str, Any],
     alpha_logp: float,
+    minimap_kwargs: dict,
     minimap_latency_range: Optional[tuple[float | None, float | None]] = None,
 ):
     # Ensure we have the FSAverage dataset downloaded
@@ -342,9 +343,7 @@ def _plot_minimap_hexel(
         tmin=0,
         tstep=1,
     )
-    warn(
-        "Plotting on the fsaverage brain. Ensure that hexel numbers match those of the fsaverage brain."
-    )
+    warn("Plotting on the fsaverage brain. Ensure that hexel numbers match those of the fsaverage brain.")
     plot_kwargs = dict(
         subject="fsaverage",
         surface=surface,
@@ -361,6 +360,8 @@ def _plot_minimap_hexel(
             lims=[0, len(expression_set.transforms) / 2, len(expression_set.transforms)],
         ),
     )
+    # Override plot kwargs with those passed
+    plot_kwargs.update(minimap_kwargs)
     # Plot left view
     lh_brain = stc.plot(hemi="lh", **plot_kwargs)
     lh_brain_fig = pyplot.gcf()
@@ -406,6 +407,8 @@ def expression_plot(
     overwrite: bool = True,
     show_legend: bool = True,
     legend_display: dict[str, str] | None = None,
+    # Extra kwargs
+    minimap_kwargs: Optional[dict] = None
 ) -> pyplot.Figure:
     """
     Generates a plot of transform expressions over time with optional display customizations.
@@ -465,6 +468,7 @@ def expression_plot(
         legend_display (dict[str, str] | None, optional): Allows grouping of multiple transforms under the same legend
             item. Provide a dictionary mapping true transform names to display names. None applies no grouping.
             Default is None.
+        minimap_kwargs (Optional[dict]): Keyword argument overrides for minimap plotting. Deafault is None.
 
     Returns:
         pyplot.Figure: The matplotlib figure object containing the generated plot.
@@ -499,6 +503,9 @@ def expression_plot(
     if minimap_latency_range is None:
         minimap_latency_range = (None, None)
     assert len(minimap_latency_range) == 2
+
+    if minimap_kwargs is None:
+        minimap_kwargs = dict()
 
     # Default colours
     cycol = cycle(color_palette("Set1"))
@@ -748,6 +755,7 @@ def expression_plot(
                 colors=color,
                 alpha_logp=sidak_corrected_alpha,
                 minimap_latency_range=minimap_latency_range,
+                minimap_kwargs=minimap_kwargs,
             )
         else:
             raise NotImplementedError()

--- a/tests/test_iterables.py
+++ b/tests/test_iterables.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kymata.entities.iterables import all_equal
+from kymata.entities.iterables import all_equal, interleave
 
 
 @pytest.fixture
@@ -49,3 +49,36 @@ def test_list_of_arrays_is_equal():
             array([0, 0]),
         ]
     )
+
+
+def test_interleave_equal_length_two_lists():
+    list_1 = [1, 2, 3, 4, 5]
+    list_2 = list("abcde")
+    interleaved = interleave(list_1, list_2)
+
+    assert interleaved == [1, "a", 2, "b", 3, "c", 4, "d", 5, "e"]
+
+
+def test_interleave_unequal_length_two_lists_first_shorter():
+    list_1 = [1, 2, 3]
+    list_2 = list("abcde")
+    interleaved = interleave(list_1, list_2)
+
+    assert interleaved == [1, "a", 2, "b", 3, "c"]
+
+
+def test_interleave_unequal_length_two_lists_second_shorter():
+    list_1 = [1, 2, 3, 4, 5]
+    list_2 = list("abc")
+    interleaved = interleave(list_1, list_2)
+
+    assert interleaved == [1, "a", 2, "b", 3, "c"]
+
+
+def test_interleave_equal_length_three_lists():
+    list_1 = [1, 2, 3, 4, 5]
+    list_2 = list("abcde")
+    list_3 = list("ABCDE")
+    interleaved = interleave(list_1, list_2, list_3)
+
+    assert interleaved == [1, "a", "A", 2, "b", "B", 3, "c", "C", 4, "d", "D", 5, "e", "E"]


### PR DESCRIPTION
Fixes #425 
(and #428)

This is as good as it gets if we want to use MNE to do the rendering

![image](https://github.com/user-attachments/assets/a614bd29-420e-40c5-b2c5-56bcee36c4a2)

This MR therefore fixes but #425, and implements a better solution for the colormap, but introduces a new more minor bug #432, which is currently unfixable.
