### PR TITLE
Specify `int64` and `float64` to avoid cross-platform issues

### DIFF
--- a/kymata/io/nkg.py
+++ b/kymata/io/nkg.py
@@ -7,7 +7,7 @@ from typing import Any
 from warnings import warn
 from zipfile import ZipFile, ZIP_LZMA
 
-from numpy import frombuffer
+from numpy import frombuffer, int64, float64
 from numpy.typing import NDArray
 from sparse import COO
 
@@ -453,9 +453,9 @@ def _load_data_current(from_path_or_file: PathType | FileType) -> dict[str, Any]
                     for c in f.readlines()
                 ]
             with zf.open(f"/{block_name}/coo-coords.bytes") as f:
-                coords: NDArray = frombuffer(f.read(), dtype=int).reshape((3, -1))
+                coords: NDArray = frombuffer(f.read(), dtype=int64).reshape((3, -1))
             with zf.open(f"/{block_name}/coo-data.bytes") as f:
-                data: NDArray = frombuffer(f.read(), dtype=float)
+                data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(zf.open(f"/{block_name}/coo-shape.txt"), encoding="utf-8") as f:
                 shape: tuple[int, ...] = tuple(int(s.strip()) for s in f.readlines())
             sparse_data = COO(coords=coords, data=data, shape=shape, prune=True, fill_value=0.0)

--- a/kymata/io/nkg_compatibility.py
+++ b/kymata/io/nkg_compatibility.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 from zipfile import ZipFile
 
-from numpy import frombuffer
+from numpy import frombuffer, int64, float64
 from numpy.typing import NDArray
 
 from kymata.entities.datatypes import LatencyDType, TransformNameDType, HexelDType
@@ -61,9 +61,10 @@ def _load_data_0_4(from_path_or_file: PathType | FileType) -> dict[str, Any]:
                     for c in f.readlines()
                 ]
             with zf.open(f"/{block_name}/coo-coords.bytes") as f:
-                coords: NDArray = frombuffer(f.read(), dtype=int).reshape((3, -1))
+                temp = frombuffer(f.read(), dtype=int64)
+                coords: NDArray = temp.reshape((3, -1))
             with zf.open(f"/{block_name}/coo-data.bytes") as f:
-                data: NDArray = frombuffer(f.read(), dtype=float)
+                data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(zf.open(f"/{block_name}/coo-shape.txt"), encoding="utf-8") as f:
                 shape: tuple[int, ...] = tuple(int(s.strip()) for s in f.readlines())
             return_dict["data"][block_name] = dict()
@@ -107,9 +108,9 @@ def _load_data_0_3(from_path_or_file: PathType | FileType) -> dict[str, Any]:
         return_dict["data"] = dict()
         for layer in layers:
             with zf.open(f"/{layer}/coo-coords.bytes") as f:
-                coords: NDArray = frombuffer(f.read(), dtype=int).reshape((3, -1))
+                coords: NDArray = frombuffer(f.read(), dtype=int64).reshape((3, -1))
             with zf.open(f"/{layer}/coo-data.bytes") as f:
-                data: NDArray = frombuffer(f.read(), dtype=float)
+                data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(
                 zf.open(f"/{layer}/coo-shape.txt"), encoding="utf-8"
             ) as f:
@@ -155,9 +156,9 @@ def _load_data_0_2(from_path_or_file: PathType | FileType) -> dict[str, Any]:
         return_dict["data"] = dict()
         for layer in layers:
             with zf.open(f"/{layer}/coo-coords.bytes") as f:
-                coords: NDArray = frombuffer(f.read(), dtype=int).reshape((3, -1))
+                coords: NDArray = frombuffer(f.read(), dtype=int64).reshape((3, -1))
             with zf.open(f"/{layer}/coo-data.bytes") as f:
-                data: NDArray = frombuffer(f.read(), dtype=float)
+                data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(
                 zf.open(f"/{layer}/coo-shape.txt"), encoding="utf-8"
             ) as f:
@@ -203,9 +204,9 @@ def _load_data_0_1(from_path_or_file: PathType | FileType) -> dict[str, Any]:
         return_dict["data"] = dict()
         for layer in ["left", "right"]:
             with zf.open(f"/{layer}/coo-coords.bytes") as f:
-                coords: NDArray = frombuffer(f.read(), dtype=int).reshape((3, -1))
+                coords: NDArray = frombuffer(f.read(), dtype=int64).reshape((3, -1))
             with zf.open(f"/{layer}/coo-data.bytes") as f:
-                data: NDArray = frombuffer(f.read(), dtype=float)
+                data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(
                 zf.open(f"/{layer}/coo-shape.txt"), encoding="utf-8"
             ) as f:

--- a/kymata/io/nkg_compatibility.py
+++ b/kymata/io/nkg_compatibility.py
@@ -61,8 +61,7 @@ def _load_data_0_4(from_path_or_file: PathType | FileType) -> dict[str, Any]:
                     for c in f.readlines()
                 ]
             with zf.open(f"/{block_name}/coo-coords.bytes") as f:
-                temp = frombuffer(f.read(), dtype=int64)
-                coords: NDArray = temp.reshape((3, -1))
+                coords: NDArray = frombuffer(f.read(), dtype=int64).reshape((3, -1))
             with zf.open(f"/{block_name}/coo-data.bytes") as f:
                 data: NDArray = frombuffer(f.read(), dtype=float64)
             with TextIOWrapper(zf.open(f"/{block_name}/coo-shape.txt"), encoding="utf-8") as f:


### PR DESCRIPTION
Byte arrays were being loaded with just `int` and `float` dtypes, which differ on Windows, so the arrays were ending up the wrong size.

The fix is to specify 64-bit ints and floats.

Fixes #399 
Fixes #408 (don't know why but it works now!)

Thanks @young-x-skyee for the help tracking this down!