### PR TITLE
Use .fif files if not specified

### DIFF
--- a/kymata/preproc/source.py
+++ b/kymata/preproc/source.py
@@ -29,7 +29,11 @@ def load_single_emeg(
 
     old_morph: forces loading of mne morph map
     """
-    if not emeg_path.suffix == ".fif":
+    # If no suffix provided, use .fif
+    if emeg_path.suffix == "":
+        emeg_path = emeg_path.with_suffix(".fif")
+    # If non-fif suffix provided, error
+    elif not emeg_path.suffix == ".fif":
         raise FileFormatError(f"Only .fif files supported: {emeg_path.name}")
 
     if inverse_operator_path is None:


### PR DESCRIPTION
- Fixes #602
  - Also addressed in #615 [here](https://github.com/kymata-atlas/kymata-core/pull/615/changes#diff-f0927749822c9e91b3eaa9b191107a0270d390205e125bc5dac6871eb8a2d9b8R151), but the present fix is better.