### PR TITLE
Audio latency and drift checker

### DIFF
--- a/kymata/dataset_config/dataset3.yaml
+++ b/kymata/dataset_config/dataset3.yaml
@@ -25,6 +25,7 @@ participants: [
               ]
 number_of_runs: 2                    # number of runs  <- 15-minute recording block from scanner
 repetitions_per_runs: 2              # number of repetitions per run  <- repeated stimulus presentations per run
+audio_stimulus_file: "stimuli/audio/F00C_dataset3.wav"
 stimulus_length: 400                 # seconds
 mri_structural_type: "T1"            # T1 | flash
 sample_rate: 1000                    # Hz

--- a/kymata/dataset_config/dataset3.yaml
+++ b/kymata/dataset_config/dataset3.yaml
@@ -44,6 +44,7 @@ remove_VEOH_and_HEOG: True
 remove_ECG: True
 automatic_bad_channel_detection_requested: False
 supress_excessive_plots_and_prompts: True
+check_drift_and_delay: True
 
 # Inverse operator
 eeg: True

--- a/kymata/dataset_config/dataset4.1.yaml
+++ b/kymata/dataset_config/dataset4.1.yaml
@@ -11,6 +11,7 @@ participants: [
               ]
 number_of_runs: 4                    # number of runs
 repetitions_per_runs: 2              # number of repetitions per run
+audio_stimulus_file: "stimuli/audio/F00C_dataset3.wav"
 stimulus_length: 400                 # seconds
 mri_structural_type: "T1"            # T1 | flash
 sample_rate: 1000                    # Hz

--- a/kymata/dataset_config/dataset4.1.yaml
+++ b/kymata/dataset_config/dataset4.1.yaml
@@ -30,6 +30,7 @@ remove_VEOH_and_HEOG: True
 remove_ECG: True
 automatic_bad_channel_detection_requested: False
 supress_excessive_plots_and_prompts: True
+check_drift_and_delay: True
 
 # Inverse operator
 eeg: True

--- a/kymata/dataset_config/dataset4.yaml
+++ b/kymata/dataset_config/dataset4.yaml
@@ -32,6 +32,7 @@ participants: [
               ]
 number_of_runs: 4                    # number of runs
 repetitions_per_runs: 2              # number of repetitions per run
+audio_stimulus_file: "stimuli/audio/stimulus.wav"
 stimulus_length: 400                 # seconds
 mri_structural_type: "T1"            # T1 | flash
 sample_rate: 1000                    # Hz

--- a/kymata/dataset_config/dataset4.yaml
+++ b/kymata/dataset_config/dataset4.yaml
@@ -8,15 +8,15 @@ mri_structurals_directory: "raw_mri_structurals"
 
 # General information related to the dataset
 participants: [
-                'pilot_01',
+                # 'pilot_01',       # 2 runs
                 'pilot_02',
                 'participant_01',
                 'participant_01b',
                 'participant_02',
                 'participant_03',
-                'participant_04',
+                # 'participant_04', # 6 repetitions
                 'participant_05',
-                'participant_07',
+                # 'participant_07', # 3 runs
                 'participant_08',
                 'participant_09',
                 'participant_10',

--- a/kymata/dataset_config/dataset4.yaml
+++ b/kymata/dataset_config/dataset4.yaml
@@ -52,6 +52,7 @@ remove_VEOH_and_HEOG: True
 remove_ECG: True
 automatic_bad_channel_detection_requested: False
 supress_excessive_plots_and_prompts: True
+check_drift_and_delay: True
 
 # Inverse operator
 eeg: True

--- a/kymata/dataset_config/dataset4.yaml
+++ b/kymata/dataset_config/dataset4.yaml
@@ -65,10 +65,10 @@ duration:   1                      # in seconds for the duration of the empty ro
 reg_method: 'empirical'            # None | 'auto'
 
 # Creation of evoked trial pipeline
-audio_delivery_latency:   0.026     # the audio stimulus is delayed by this amount in seconds
+audio_delivery_latency:   0.019     # 0.026     # the audio stimulus is delayed by this amount in seconds
 visual_delivery_latency:  0.017     # the visual stimulus is delayed by this amount in seconds
 tactile_delivery_latency: null      # the tactile stimulus is delayed by this amount in seconds
-audio_delivery_drift_correction:   0.0005404  # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
+audio_delivery_drift_correction:   0.0005388  # 0.0005404  # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 visual_delivery_drift_correction:  0.0004937  # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 tactile_delivery_drift_correction: null       # drift - in seconds per second (minus number means stimulus is shorter than it should be relative to the acquisition computer)
 latency_range: [ -0.2 , 0.8 ]  # range of latencies to check, in seconds

--- a/kymata/dataset_config/dataset4.yaml
+++ b/kymata/dataset_config/dataset4.yaml
@@ -8,15 +8,15 @@ mri_structurals_directory: "raw_mri_structurals"
 
 # General information related to the dataset
 participants: [
-                # 'pilot_01',       # 2 runs
+                'pilot_01',       # 2 runs
                 'pilot_02',
                 'participant_01',
                 'participant_01b',
                 'participant_02',
                 'participant_03',
-                # 'participant_04', # 6 repetitions
+                'participant_04', # 6 repetitions
                 'participant_05',
-                # 'participant_07', # 3 runs
+                'participant_07', # 3 runs
                 'participant_08',
                 'participant_09',
                 'participant_10',
@@ -38,7 +38,7 @@ mri_structural_type: "T1"            # T1 | flash
 sample_rate: 1000                    # Hz
 
 # Seed (if needed)
-random_seed_gridsearch: None
+random_seed_gridsearch: 17
 
 # Preprocessing pipeline
 meg_manufacturer: 'MEGIN'

--- a/kymata/entities/rudimentary.py
+++ b/kymata/entities/rudimentary.py
@@ -21,6 +21,9 @@ def get_coerce(
 ) -> T_default | T_coerce:
     """
     Return `coerce(d[key])` if `key` exists, otherwise `default`.
+
+    This solves a problem were I want to do `float(d.get(key, None))` but I can't coerce the default. Now I can instead
+    do `get_coerce(d, key, float, None)`.
     """
     if key in d:
         return coerce(d[key])

--- a/kymata/entities/rudimentary.py
+++ b/kymata/entities/rudimentary.py
@@ -20,4 +20,7 @@ def get_coerce(
         default: T_default,
 ) -> T_default | T_coerce:
     """Return ``coerce(d[key])`` if ``key`` exists, otherwise ``default``."""
-    return default if key not in d else coerce(d[key])
+    if key in d:
+        return coerce(d[key])
+    else:
+        return default

--- a/kymata/entities/rudimentary.py
+++ b/kymata/entities/rudimentary.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, TypeVar, Hashable, Any, Callable, Mapping
 
 
 class Point2d(NamedTuple):
@@ -7,3 +7,17 @@ class Point2d(NamedTuple):
     """
     x: float
     y: float
+
+
+T_coerce = TypeVar("T_coerce")
+T_default = TypeVar("T_default")
+
+
+def get_coerce(
+        d: Mapping[Hashable, Any],
+        key: Hashable,
+        coerce: Callable[[Any], T_coerce],
+        default: T_default,
+) -> T_default | T_coerce:
+    """Return ``coerce(d[key])`` if ``key`` exists, otherwise ``default``."""
+    return default if key not in d else coerce(d[key])

--- a/kymata/entities/rudimentary.py
+++ b/kymata/entities/rudimentary.py
@@ -19,7 +19,9 @@ def get_coerce(
         coerce: Callable[[Any], T_coerce],
         default: T_default,
 ) -> T_default | T_coerce:
-    """Return ``coerce(d[key])`` if ``key`` exists, otherwise ``default``."""
+    """
+    Return `coerce(d[key])` if `key` exists, otherwise `default`.
+    """
     if key in d:
         return coerce(d[key])
     else:

--- a/kymata/invokers/invoker_create_trialwise_data.py
+++ b/kymata/invokers/invoker_create_trialwise_data.py
@@ -15,17 +15,16 @@ _app = App()
 @_app.default
 def main(
         config: str = "dataset4.yaml",
-        check_drift: bool = False,
 ) -> None:
     """
     Create trialwise data
 
     Args:
         config:
-        check_drift (bool): Whether to check the config drift against the stimulus
 
     """
     config = load_config(Path(__file__).parent.parent / "dataset_config" / config)
+    check_drift = config.get("check_drift_and_delay", False)
 
     create_trialwise_data(
         data_root_dir=get_root_dir(config),

--- a/kymata/invokers/invoker_create_trialwise_data.py
+++ b/kymata/invokers/invoker_create_trialwise_data.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from logging import basicConfig, INFO
 from pathlib import Path
 
+from kymata.entities.rudimentary import get_coerce
 from kymata.io.config import load_config, get_root_dir
 from kymata.io.logging import log_message, date_format
 from kymata.preproc.data_cleansing import create_trialwise_data
@@ -17,9 +18,13 @@ def main(config_filename: str):
         dataset_directory_name=config["dataset_directory_name"],
         list_of_participants=config["participants"],
         repetitions_per_runs=config["repetitions_per_runs"],
+        data_sample_rate=config["sample_rate"],
         stimulus_length=config["stimulus_length"],
         number_of_runs=config["number_of_runs"],
         latency_range=config["latency_range"],
+        check_drift_with_audio_stim=config["audio_stimulus_file"] if args.check_drift else None,
+        reference_drift=get_coerce(config, key="audio_delivery_drift_correction", coerce=float, default=None),
+        reference_delay=get_coerce(config, key="audio_delivery_latency", coerce=float, default=None),
     )
 
 
@@ -27,5 +32,6 @@ if __name__ == "__main__":
     basicConfig(format=log_message, datefmt=date_format, level=INFO)
     parser = ArgumentParser(description="Create Trialwise Data")
     parser.add_argument("--config", type=str, default="dataset4.yaml")
+    parser.add_argument("--check-drift", action="store_true")
     args = parser.parse_args()
     main(config_filename=args.config)

--- a/kymata/invokers/invoker_create_trialwise_data.py
+++ b/kymata/invokers/invoker_create_trialwise_data.py
@@ -25,9 +25,7 @@ def main(
         check_drift (bool): Whether to check the config drift against the stimulus
 
     """
-    config = load_config(
-        str(Path(Path(__file__).parent.parent, "dataset_config", config))
-    )
+    config = load_config(Path(__file__).parent.parent / "dataset_config" / config)
 
     create_trialwise_data(
         data_root_dir=get_root_dir(config),

--- a/kymata/invokers/run_gridsearch.py
+++ b/kymata/invokers/run_gridsearch.py
@@ -2,9 +2,9 @@ from logging import getLogger, basicConfig, INFO
 from pathlib import Path
 import time
 from sys import stdout
-from typing import Optional, Literal
+from typing import Optional, Literal, Annotated
 
-from cyclopts import App
+from cyclopts import App, Parameter
 
 from kymata.datasets.data_root import data_root_path
 from kymata.gridsearch.plain import do_gridsearch
@@ -38,7 +38,7 @@ def get_config_value_with_fallback(config: dict, config_key: str, fallback):
 def main(
         config: str,
         # Transforms
-        transform_name: list[str],
+        transform_name: Annotated[list[str], Parameter(consume_multiple=True)],
         input_stream: Literal["auditory", "visual", "tactile"],
         transform_path: str = "predicted_function_contours/GMSloudness/stimulisig",
         transform_sample_rate: float = 1000,

--- a/kymata/io/audio.py
+++ b/kymata/io/audio.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import numpy as np
+from scipy.io import wavfile
+
+
+def load_wav_as_floats(path: str | Path, mix_to_mono: bool = False) -> tuple[np.ndarray, int]:
+    """
+    Load a WAV file as float32.
+    
+    If mix_to_mono is True, all channels will be averaged to get the mono channel
+
+    Returns:
+        (audio, sample_rate):
+            audio: numpy array with dtype float32 and shape:
+              - (samples,) for mono
+              - (samples, channels) for stereo and other multi-channel
+            sample_rate: float (sample rate in Hz)
+    """
+    sample_rate, audio = wavfile.read(path)
+
+    if np.issubdtype(audio.dtype, np.floating):
+        audio = audio.astype(np.float32, copy=False)
+    elif np.issubdtype(audio.dtype, np.signedinteger):
+        audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
+    elif np.issubdtype(audio.dtype, np.unsignedinteger):
+        info = np.iinfo(audio.dtype)
+        audio = (audio.astype(np.float32) - (info.max + 1) / 2) / (
+            (info.max + 1) / 2
+        )
+    else:
+        raise TypeError(f"Unsupported WAV dtype: {audio.dtype}")
+    
+    if mix_to_mono and audio.ndim > 1:
+        if audio.ndim == 2:
+            audio = audio.mean(axis=1)
+        else:
+            raise ValueError(f"Too many dimensions in audio array (expected 2, got {audio.ndim})")
+
+    return audio, sample_rate

--- a/kymata/io/logging.py
+++ b/kymata/io/logging.py
@@ -1,2 +1,28 @@
 log_message = "%(asctime)s | %(levelname).2s | %(filename)s:%(lineno)d | \t%(message)s"
 date_format = "%Y-%m-%d %H:%M:%S"
+
+
+def describe_higher_lower_than(val: float, reference: float = 0, include_preposition: bool = True) -> str:
+    """
+    Compares `val` to `reference` and returns:
+
+    - "higher than" if val is higher than reference
+    - "lower than" if val is lower than reference
+    - "the same as" if val is the same as reference
+
+    prepositions ("than", "as") and their preceding spaces are omitted if include_preposition is set to False.
+    """
+    if val > reference:
+        comparative_adjective = "higher"
+        preposition = "than"
+    elif val < reference:
+        comparative_adjective = "lower"
+        preposition = "than"
+    else:
+        comparative_adjective = "the same"
+        preposition = "as"
+
+    if include_preposition:
+        return f"{comparative_adjective} {preposition}"
+    else:
+        return comparative_adjective

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -792,7 +792,7 @@ def create_trialwise_data(
             # Check if individualised delays are approximately symmetric about zero.
             # If they are, this is treated as a serious problem. A systematic bias in delays could mean the config may
             # be set wrong.
-            if abs(diffs_df["Delay difference"].mean()) > reference_delay:  # I'm using a relatively large threshold here because it will be correctly anyway
+            if abs(diffs_df["Delay difference"].mean()) > reference_delay:  # I'm using a relatively large threshold here because it will be corrected anyway
                 raise RuntimeError(f"There seems to be a systematic error in the delays for participant {p}. "
                                    f"Does the delay value in the config need changing? "
                                    f"Check the output in {diffs_path.name}.")

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -714,17 +714,16 @@ def create_trialwise_data(
         print(f"{Fore.GREEN}{Style.BRIGHT}... extract and save evoked data{Style.RESET_ALL}")
 
         # Extract trial instances ('epochs')
-        _tmin = latency_range[0]
-        _tmax = (
+        tmin = latency_range[0]
+        tmax = (
             stimulus_length
             # extra padding at the end to accommodate range of latencies
             + latency_range[1]
             # Extra space to account for audio latency drift
             + 2
         )
-
         epochs = mne.Epochs(raw, repetition_events, event_id=None,
-                            tmin=_tmin, tmax=_tmax, baseline=(None, None), preload=True,
+                            tmin=tmin, tmax=tmax, baseline=(None, None), preload=True,
                             picks=picks)
         _logger.info(f"Created epochs with {len(epochs.ch_names)} channels")
 

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -699,7 +699,7 @@ def create_trialwise_data(
         ), f"{len(repetition_events)=} but {number_of_runs * repetitions_per_runs=}"
 
         # Denote picks
-        include = []  # ['MISC006']  # MISC05, trigger channels etc, if needed
+        include = ['MISC006']  # MISC006, trigger channels etc, if needed
         picks: NDArray = mne.pick_types(
             raw.info, meg=True, eeg=True, stim=False, exclude="bads", include=include
         )
@@ -739,7 +739,7 @@ def create_trialwise_data(
 
         # check_audio_drift_and_delay
         for i in range(len(repetition_events)):
-            xxx = check_audio_drift_and_delay()
+            xxx = check_audio_drift_and_delay(epochs[str(i)], "MISCO6", config_delay, config_drift)
             printout xxx
             save txt in xxx.
 
@@ -855,11 +855,11 @@ def _plot_bad_chans(auto_scores):
     # vmin=nanmin(limits) with vmax=nanmax(limits) to print flat channels
 
 
-def check_audio_drift_and_delay(epoch, audiochannel, config_delay, config_drift):
+def check_audio_drift_and_delay(epoch, audiochannel:string, config_delay, config_drift):
     # doc
 
-    xxx = extract audiochannel
+    xxx = extract audiochannel(audiochannel)
 
-    xxx = fit_drift_delay(xxx)
+    xxx = fit_drift_delay(xxx, x, x, x, x, x, x, x)
 
     return xxx

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -797,6 +797,7 @@ def create_trialwise_data(
 
             # Apply delay_diffs to individual repetitions before saving and averaging, so that the config delay can now
             # be used without error. We'll do this by editing the repetition events and recomputing the epochs
+            _logger.info("Applying individualised delays to EMEG data")
             repetition_events = _apply_delays(repetition_events, data_sr=data_sample_rate, delays=diffs_df["Delay difference"].tolist())
             epochs = mne.Epochs(raw, repetition_events, event_id=None,
                                 tmin=tmin, tmax=tmax, baseline=(None, None), preload=True,

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -765,15 +765,34 @@ def create_trialwise_data(
     
                 difference_vals.append((p, i, drift_diff, delay_diff))
     
-                _logger.info(f"Detected drift for participant {p} repetition {i} was {drift_diff}, "
+                _logger.info(f"Detected drift for participant {p} repetition {i}/{len(repetition_events)} was {drift_diff} "
                              f"{describe_higher_lower_than(drift_diff)} the reference value of {reference_drift}")
-                _logger.info(f"Detected drift for participant {p} repetition {i} was {drift_diff}, "
+                _logger.info(f"Detected delay for participant {p} repetition {i}/{len(repetition_events)} was {delay_diff} "
                              f"{describe_higher_lower_than(delay_diff)} the reference value of {reference_delay}")
     
             # Save drift and delay vals to csv
-            DataFrame.from_records(
+            diffs_df = DataFrame.from_records(
                 difference_vals, columns=["Participant", "Repetition", "Drift difference", "Delay difference"]
-            ).to_csv(logs_path / f"drift_delay_diffs_{p}.csv", index=False)
+            )
+            diffs_path = logs_path / f"drift_delay_diffs_{p}.csv"
+            diffs_df.to_csv(diffs_path, index=False)
+
+            # Check any drifts are wrong.
+            # If they are, this is treated as a serious problem. Either all the diffs are nonzero and identical, in
+            # which case the config is wrong (for this participant); or they are not all the same and we don't yet have
+            # a way to apply individualised stretches to the emeg data before averaging.
+            if (diffs_df["Drift difference"].abs() > 1e-7).any():
+                raise RuntimeError(f"The differences on some drifts for participant {p} were too large. "
+                                   f"Does the drift value in the config need changing? "
+                                   f"Check the output in {diffs_path.name} to ensure constant drifts repetitions.")
+
+            # Check if individualised delays are approximately symmetric about zero.
+            # If they are, this is treated as a serious problem. A systematic bias in delays could mean the config may
+            # be set wrong.
+            if abs(diffs_df["Delay difference"].mean()) > 1e-3:  # Note: I am not sure this is the best tolerance to use; perhaps use 2e-3 or something to allow for some variance without erroring
+                raise RuntimeError(f"There seems to be a systematic error in the delays for participant {p}. "
+                                   f"Does the delay value in the config need changing? "
+                                   f"Check the output in {diffs_path.name}.")
 
         # Save individual repetitions
         for i in range(len(repetition_events)):

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -792,7 +792,7 @@ def create_trialwise_data(
             # Check if individualised delays are approximately symmetric about zero.
             # If they are, this is treated as a serious problem. A systematic bias in delays could mean the config may
             # be set wrong.
-            if abs(diffs_df["Delay difference"].mean()) > 5e-3:  # I'm changing this to be consistent with the latency interval
+            if abs(diffs_df["Delay difference"].mean()) > reference_delay:  # I'm using a relatively large threshold here because it will be correctly anyway
                 raise RuntimeError(f"There seems to be a systematic error in the delays for participant {p}. "
                                    f"Does the delay value in the config need changing? "
                                    f"Check the output in {diffs_path.name}.")

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -15,6 +15,7 @@ import numpy as np
 from kymata.io.cli import print_with_color, input_with_color
 from kymata.io.config import load_config, modify_param_config
 from kymata.io.file import PathType
+from kymata.preproc.sensor import fit_drift_delay
 
 _logger = getLogger(__name__)
 
@@ -736,6 +737,12 @@ def create_trialwise_data(
         dropfig = epochs.plot_drop_log(subject=p)
         dropfig.savefig(Path(logs_path, f"drop-log_{p}.jpg"))
 
+        # check_audio_drift_and_delay
+        for i in range(len(repetition_events)):
+            xxx = check_audio_drift_and_delay()
+            printout xxx
+            save txt in xxx.
+
         # Save individual repetitions
         for i in range(len(repetition_events)):
             evoked = epochs[str(i)].average()
@@ -846,3 +853,13 @@ def _plot_bad_chans(auto_scores):
 
     # Replace the word “noisy” with “flat”, and replace
     # vmin=nanmin(limits) with vmax=nanmax(limits) to print flat channels
+
+
+def check_audio_drift_and_delay(epoch, audiochannel, config_delay, config_drift):
+    # doc
+
+    xxx = extract audiochannel
+
+    xxx = fit_drift_delay(xxx)
+
+    return xxx

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -738,16 +738,13 @@ def create_trialwise_data(
 
         # check_audio_drift_and_delay
         if check_drift_with_audio_stim is not None:
-            check_drift_with_audio_stim = Path(
-                data_root_dir,
-                dataset_directory_name,
-                check_drift_with_audio_stim)
+            check_drift_with_audio_stim = Path(data_root_dir, dataset_directory_name, check_drift_with_audio_stim)
             _logger.info(f"Checking drift versus stimulus {check_drift_with_audio_stim!s}")
 
             assert reference_drift is not None, "reference drift required"
             assert reference_delay is not None, "reference delay required"
 
-            # Load stimulus
+            _logger.info(f"Loading stimulus file from {check_drift_with_audio_stim.name}")
             if check_drift_with_audio_stim.suffix == ".wav":
                 stimulus, stim_sr = load_wav_as_floats(check_drift_with_audio_stim, mix_to_mono=True)
             else:

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -709,7 +709,6 @@ def create_trialwise_data(
         picks = np.array(mne.pick_types(raw.info, meg=True,  eeg=True,  stim=False, exclude="bads",
                                         # add in trigger channels etc, if needed
                                         include=[]))
-        picks_audio_misc = np.array(mne.pick_types(raw.info, include=[CHANNEL_AUDIO_MISC_RECORDING]))
         _logger.info(f"Picked {picks.shape} channels out of {len(raw.info['ch_names'])}")
 
         print(f"{Fore.GREEN}{Style.BRIGHT}... extract and save evoked data{Style.RESET_ALL}")
@@ -727,9 +726,6 @@ def create_trialwise_data(
         epochs = mne.Epochs(raw, repetition_events, event_id=None,
                             tmin=_tmin, tmax=_tmax, baseline=(None, None), preload=True,
                             picks=picks)
-        epochs_misc = mne.Epochs(raw, repetition_events, event_id=None,
-                                 tmin=_tmin, tmax=_tmax, baseline=(None, None), preload=True,
-                                 picks=picks_audio_misc)
         _logger.info(f"Created epochs with {len(epochs.ch_names)} channels")
 
         # Log which channels are worst
@@ -744,6 +740,10 @@ def create_trialwise_data(
             assert reference_drift is not None, "reference drift required"
             assert reference_delay is not None, "reference delay required"
 
+            picks_audio_misc = np.array(mne.pick_types(raw.info, include=[CHANNEL_AUDIO_MISC_RECORDING]))
+            epochs_misc = mne.Epochs(raw, repetition_events, event_id=None, baseline=(None, None), preload=True,
+                                     tmin=0, tmax=stimulus_length, picks=picks_audio_misc)
+
             _logger.info(f"Loading stimulus file from {check_drift_with_audio_stim.name}")
             if check_drift_with_audio_stim.suffix == ".wav":
                 stimulus, stim_sr = load_wav_as_floats(check_drift_with_audio_stim, mix_to_mono=True)
@@ -753,7 +753,7 @@ def create_trialwise_data(
             difference_vals = []
             for i in range(len(repetition_events)):
     
-                audio_chan_recording: NDArray = _extract_audio_chan(epochs_misc[str(i)], CHANNEL_AUDIO_MISC_RECORDING)
+                audio_chan_recording: NDArray = epochs_misc[str(i)].get_data().squeeze()
     
                 drift_diff, delay_diff = fit_drift_delay(
                     stim_actual=stimulus,
@@ -882,7 +882,3 @@ def _plot_bad_chans(auto_scores):
 
     # Replace the word “noisy” with “flat”, and replace
     # vmin=nanmin(limits) with vmax=nanmax(limits) to print flat channels
-
-
-def _extract_audio_chan(epoch, audio_chan):
-    return epoch[audio_chan]

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -4,22 +4,25 @@ from typing import Optional
 
 from colorama import Fore, Style
 import mne
-from numpy import nanmin
+import numpy as np
 from numpy.typing import NDArray
 from pandas import DataFrame, Index
 from pathlib import Path
 from matplotlib import pyplot as plt
 import seaborn as sns
-import numpy as np
 
+from kymata.io.audio import load_wav_as_floats
 from kymata.io.cli import print_with_color, input_with_color
 from kymata.io.config import load_config, modify_param_config
 from kymata.io.file import PathType
+from kymata.io.logging import describe_higher_lower_than
 from kymata.preproc.sensor import fit_drift_delay
+
 
 _logger = getLogger(__name__)
 
 CHANNEL_TRIGGER = "STI101"
+CHANNEL_AUDIO_MISC_RECORDING = 'MISC006'  # MISC006 is local recording of audio stimulus presentation
 TRIGGER_REP_ONSET = 3
 
 
@@ -638,13 +641,17 @@ def estimate_noise_cov(
 
 
 def create_trialwise_data(
-    data_root_dir: PathType,
-    dataset_directory_name: str,
-    list_of_participants: list[str],
-    repetitions_per_runs: int,
-    stimulus_length: int,  # seconds
-    number_of_runs: int,
-    latency_range: tuple[float, float],  # seconds
+        data_root_dir: PathType,
+        dataset_directory_name: str,
+        list_of_participants: list[str],
+        repetitions_per_runs: int,
+        stimulus_length: int,  # seconds
+        number_of_runs: int,
+        latency_range: tuple[float, float],  # seconds
+        data_sample_rate: float,  # Hz
+        reference_drift: Optional[float] = None,
+        reference_delay: Optional[float] = None,
+        check_drift_with_audio_stim: Optional[str] = None,
 ):
     """Create trials objects from the raw data files (still in sensor space)"""
 
@@ -698,18 +705,14 @@ def create_trialwise_data(
             len(repetition_events) == number_of_runs * repetitions_per_runs
         ), f"{len(repetition_events)=} but {number_of_runs * repetitions_per_runs=}"
 
-        # Denote picks
-        include = ['MISC006']  # MISC006, trigger channels etc, if needed
-        picks: NDArray = mne.pick_types(
-            raw.info, meg=True, eeg=True, stim=False, exclude="bads", include=include
-        )
-        _logger.info(
-            f"Picked {picks.shape} channels out of {len(raw.info['ch_names'])}"
-        )
+        # Define picks
+        picks = np.array(mne.pick_types(raw.info, meg=True,  eeg=True,  stim=False, exclude="bads",
+                                        # add in trigger channels etc, if needed
+                                        include=[]))
+        picks_audio_misc = np.array(mne.pick_types(raw.info, include=[CHANNEL_AUDIO_MISC_RECORDING]))
+        _logger.info(f"Picked {picks.shape} channels out of {len(raw.info['ch_names'])}")
 
-        print(
-            f"{Fore.GREEN}{Style.BRIGHT}... extract and save evoked data{Style.RESET_ALL}"
-        )
+        print(f"{Fore.GREEN}{Style.BRIGHT}... extract and save evoked data{Style.RESET_ALL}")
 
         # Extract trial instances ('epochs')
         _tmin = latency_range[0]
@@ -721,41 +724,70 @@ def create_trialwise_data(
             + 2
         )
 
-        epochs = mne.Epochs(
-            raw,
-            repetition_events,
-            None,
-            _tmin,
-            _tmax,
-            picks=picks,
-            baseline=(None, None),
-            preload=True,
-        )
+        epochs = mne.Epochs(raw, repetition_events, event_id=None,
+                            tmin=_tmin, tmax=_tmax, baseline=(None, None), preload=True,
+                            picks=picks)
+        epochs_misc = mne.Epochs(raw, repetition_events, event_id=None,
+                                 tmin=_tmin, tmax=_tmax, baseline=(None, None), preload=True,
+                                 picks=picks_audio_misc)
         _logger.info(f"Created epochs with {len(epochs.ch_names)} channels")
 
         # Log which channels are worst
         dropfig = epochs.plot_drop_log(subject=p)
-        dropfig.savefig(Path(logs_path, f"drop-log_{p}.jpg"))
+        dropfig.savefig(logs_path / f"drop-log_{p}.jpg")
 
         # check_audio_drift_and_delay
-        for i in range(len(repetition_events)):
-            xxx = check_audio_drift_and_delay(epochs[str(i)], "MISCO6", config_delay, config_drift)
-            printout xxx
-            save txt in xxx.
+        if check_drift_with_audio_stim is not None:
+            check_drift_with_audio_stim = Path(
+                data_root_dir,
+                dataset_directory_name,
+                check_drift_with_audio_stim)
+            _logger.info(f"Checking drift versus stimulus {check_drift_with_audio_stim!s}")
+
+            assert reference_drift is not None, "reference drift required"
+            assert reference_delay is not None, "reference delay required"
+
+            # Load stimulus
+            if check_drift_with_audio_stim.suffix == ".wav":
+                stimulus, stim_sr = load_wav_as_floats(check_drift_with_audio_stim, mix_to_mono=True)
+            else:
+                raise NotImplementedError()
+
+            difference_vals = []
+            for i in range(len(repetition_events)):
+    
+                audio_chan_recording: NDArray = _extract_audio_chan(epochs_misc[str(i)], CHANNEL_AUDIO_MISC_RECORDING)
+    
+                drift_diff, delay_diff = fit_drift_delay(
+                    stim_actual=stimulus,
+                    stim_misc_recording=audio_chan_recording,
+                    stim_sr=stim_sr,
+                    misc_sr=data_sample_rate,
+                    reference_drift=reference_drift,
+                    reference_delay=reference_delay,
+                )
+    
+                difference_vals.append((p, i, drift_diff, delay_diff))
+    
+                _logger.info(f"Detected drift for participant {p} repetition {i} was {drift_diff}, "
+                             f"{describe_higher_lower_than(drift_diff)} the reference value of {reference_drift}")
+                _logger.info(f"Detected drift for participant {p} repetition {i} was {drift_diff}, "
+                             f"{describe_higher_lower_than(delay_diff)} the reference value of {reference_delay}")
+    
+            # Save drift and delay vals to csv
+            DataFrame.from_records(
+                difference_vals, columns=["Participant", "Repetition", "Drift difference", "Delay difference"]
+            ).to_csv(logs_path / f"drift_delay_diffs_{p}.csv", index=False)
 
         # Save individual repetitions
         for i in range(len(repetition_events)):
             evoked = epochs[str(i)].average()
-            _logger.info(
-                f"Individual evokeds created with {len(evoked.ch_names)} channels (i.e. {evoked.data.shape=})"
-            )
+            _logger.info(f"Individual evokeds created with {len(evoked.ch_names)} channels (i.e. {evoked.data.shape=})")
             evoked.save(Path(evoked_path, f"{p}_rep{i}.fif"), overwrite=True)
 
         # Average over repetitions
         evoked = epochs.average()
-        _logger.info(
-            f"Average evokeds created with {len(evoked.ch_names)} channels (i.e. {evoked.data.shape=})"
-        )
+        _logger.info(f"Average evokeds created with {len(evoked.ch_names)} channels (i.e. {evoked.data.shape=})")
 
         evoked.save(Path(evoked_path, f"{p}-ave.fif"), overwrite=True)
 
@@ -837,7 +869,7 @@ def _plot_bad_chans(auto_scores):
     # Now, adjust the color range to highlight segments that exceeded the limit.
     sns.heatmap(
         data=data_to_plot,
-        vmin=nanmin(limits),  # bads in input data have NaN limits
+        vmin=np.nanmin(limits),  # bads in input data have NaN limits
         cmap="Reds",
         cbar_kws=dict(label="Score"),
         ax=ax[1],
@@ -855,11 +887,5 @@ def _plot_bad_chans(auto_scores):
     # vmin=nanmin(limits) with vmax=nanmax(limits) to print flat channels
 
 
-def check_audio_drift_and_delay(epoch, audiochannel:string, config_delay, config_drift):
-    # doc
-
-    xxx = extract audiochannel(audiochannel)
-
-    xxx = fit_drift_delay(xxx, x, x, x, x, x, x, x)
-
-    return xxx
+def _extract_audio_chan(epoch, audio_chan):
+    return epoch[audio_chan]

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -5,6 +5,7 @@ from typing import Optional
 from colorama import Fore, Style
 import mne
 import numpy as np
+from mne import Epochs
 from numpy.typing import NDArray
 from pandas import DataFrame, Index
 from pathlib import Path
@@ -794,6 +795,13 @@ def create_trialwise_data(
                                    f"Does the delay value in the config need changing? "
                                    f"Check the output in {diffs_path.name}.")
 
+            # Apply delay_diffs to individual repetitions before saving and averaging, so that the config delay can now
+            # be used without error. We'll do this by editing the repetition events and recomputing the epochs
+            repetition_events = _apply_delays(repetition_events, data_sr=data_sample_rate, delays=diffs_df["Delay difference"].tolist())
+            epochs = mne.Epochs(raw, repetition_events, event_id=None,
+                                tmin=tmin, tmax=tmax, baseline=(None, None), preload=True,
+                                picks=picks)
+
         # Save individual repetitions
         for i in range(len(repetition_events)):
             evoked = epochs[str(i)].average()
@@ -805,6 +813,12 @@ def create_trialwise_data(
         _logger.info(f"Average evokeds created with {len(evoked.ch_names)} channels (i.e. {evoked.data.shape=})")
 
         evoked.save(Path(evoked_path, f"{p}-ave.fif"), overwrite=True)
+
+
+def _apply_delays(events: NDArray, data_sr: float, delays: list[float]) -> NDArray:
+    sample_shifts = np.round(np.array(delays) * data_sr).astype(int)  # seconds * samples-per-second
+    events[:, 0] += sample_shifts  # TODO: I'm I doing this in the right direction?!
+    return events
 
 
 def apply_automatic_bad_channel_detection(

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -792,7 +792,7 @@ def create_trialwise_data(
             # Check if individualised delays are approximately symmetric about zero.
             # If they are, this is treated as a serious problem. A systematic bias in delays could mean the config may
             # be set wrong.
-            if abs(diffs_df["Delay difference"].mean()) > reference_delay:  # I'm using a relatively large threshold here because it will be corrected anyway
+            if abs(diffs_df["Delay difference"].mean()) > 5e-3:  # I'm changing this to be consistent with the latency interval
                 raise RuntimeError(f"There seems to be a systematic error in the delays for participant {p}. "
                                    f"Does the delay value in the config need changing? "
                                    f"Check the output in {diffs_path.name}.")

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -670,7 +670,10 @@ def create_trialwise_data(
     )
     trialwise_sensorspace_dir.mkdir(exist_ok=True)
 
-    evoked_path = Path(trialwise_sensorspace_dir, "evoked_data")
+    if check_drift_with_audio_stim is None:
+        evoked_path = Path(trialwise_sensorspace_dir, "evoked_data")
+    else:
+        evoked_path = Path(trialwise_sensorspace_dir, "evoked_data_with_delay_correction")
     evoked_path.mkdir(exist_ok=True)
 
     logs_path = Path(trialwise_sensorspace_dir, "logs")
@@ -781,7 +784,7 @@ def create_trialwise_data(
             # If they are, this is treated as a serious problem. Either all the diffs are nonzero and identical, in
             # which case the config is wrong (for this participant); or they are not all the same and we don't yet have
             # a way to apply individualised stretches to the emeg data before averaging.
-            if (diffs_df["Drift difference"].abs() > 1e-7).any():
+            if (diffs_df["Drift difference"].abs() > 5e-3 * stimulus_length).any(): # I'm changing this to be consistent with the latency interval
                 raise RuntimeError(f"The differences on some drifts for participant {p} were too large. "
                                    f"Does the drift value in the config need changing? "
                                    f"Check the output in {diffs_path.name} to ensure constant drifts repetitions.")
@@ -789,7 +792,7 @@ def create_trialwise_data(
             # Check if individualised delays are approximately symmetric about zero.
             # If they are, this is treated as a serious problem. A systematic bias in delays could mean the config may
             # be set wrong.
-            if abs(diffs_df["Delay difference"].mean()) > 1e-3:  # Note: I am not sure this is the best tolerance to use; perhaps use 2e-3 or something to allow for some variance without erroring
+            if abs(diffs_df["Delay difference"].mean()) > 5e-3:  # I'm changing this to be consistent with the latency interval
                 raise RuntimeError(f"There seems to be a systematic error in the delays for participant {p}. "
                                    f"Does the delay value in the config need changing? "
                                    f"Check the output in {diffs_path.name}.")
@@ -817,7 +820,7 @@ def create_trialwise_data(
 
 def _apply_delays(events: NDArray, data_sr: float, delays: list[float]) -> NDArray:
     sample_shifts = np.round(np.array(delays) * data_sr).astype(int)  # seconds * samples-per-second
-    events[:, 0] += sample_shifts  # TODO: I'm I doing this in the right direction?!
+    events[:, 0] += sample_shifts
     return events
 
 

--- a/kymata/preproc/data_cleansing.py
+++ b/kymata/preproc/data_cleansing.py
@@ -5,7 +5,6 @@ from typing import Optional
 from colorama import Fore, Style
 import mne
 import numpy as np
-from mne import Epochs
 from numpy.typing import NDArray
 from pandas import DataFrame, Index
 from pathlib import Path

--- a/kymata/preproc/sensor.py
+++ b/kymata/preproc/sensor.py
@@ -89,6 +89,7 @@ def _hilbert_envolope(signal: NDArray) -> NDArray:
     return np.abs(hilbert(np.asarray(signal, dtype=float)))
 
 
+# TODO: Am I doing this in the right direction to fit with how it's done inside the gridsearch?
 def _stretch_signal(signal: NDArray, sample_rate: float, stretch: float, delay: float) -> NDArray:
     signal = np.asarray(signal, dtype=float)
     n_samples = len(signal)

--- a/kymata/preproc/sensor.py
+++ b/kymata/preproc/sensor.py
@@ -6,9 +6,9 @@ from scipy.signal import hilbert, resample
 
 
 def fit_drift_delay(
-        stimulus: NDArray,
-        misc: NDArray,
-        stimulus_sr: float,
+        stim_actual: NDArray,
+        stim_misc_recording: NDArray,
+        stim_sr: float,
         misc_sr: float,
         reference_drift: float = 0,
         reference_delay: float = 0,
@@ -21,9 +21,9 @@ def fit_drift_delay(
     delay and drift of the EMEG recording.
 
     Args:
-        stimulus (NDArray): a (samples,)-sized array of the actual stimulus
-        misc (NDArray): a (samples,)-sized array of the misc channel
-        stimulus_sr (float): sample rate of the stimulus (Hz)
+        stim_actual (NDArray): a (samples,)-sized array of the actual stimulus
+        stim_misc_recording (NDArray): a (samples,)-sized array of the misc channel recording the stimulus presentation
+        stim_sr (float): sample rate of the stimulus (Hz)
         misc_sr (float): sample rate of the misc channel (Hz)
         reference_drift (reference): a reference drift (s/s), usually taken from the config file
         reference_delay (reference): a reference delay (s), usually taken from the config file
@@ -37,23 +37,23 @@ def fit_drift_delay(
             [1]: The actual delay, relative to the reference (actual - reference).
     """
 
-    stimulus_envelope = _hilbert_envolope(stimulus)
-    misc_envelope = _hilbert_envolope(misc)
+    actual_envelope = _hilbert_envolope(stim_actual)
+    recorded_envelope = _hilbert_envolope(stim_misc_recording)
 
     # Remove DC and normalise
-    stimulus_envelope -= stimulus_envelope.mean()
-    misc_envelope -= misc_envelope.mean()
+    actual_envelope -= actual_envelope.mean()
+    recorded_envelope -= recorded_envelope.mean()
     with np.errstate(divide="raise"):
-        stimulus_envelope /= norm(stimulus_envelope)
-        misc_envelope /= norm(misc_envelope)
+        actual_envelope /= norm(actual_envelope)
+        recorded_envelope /= norm(recorded_envelope)
 
     # Resample to same sample rate
-    if misc_sr > stimulus_sr:
-        raise ValueError(f"Highly unexpected for misc sample rate ({misc_sr}) to be higher than stimulus sample rate ({stimulus_sr})")
-    if misc_sr < stimulus_sr:
-        resampled_n = round(len(stimulus_envelope) * misc_sr / stimulus_sr)
-        stimulus_envelope = resample(stimulus_envelope, resampled_n)
-        stimulus_sr = misc_sr
+    if misc_sr > stim_sr:
+        raise ValueError(f"Highly unexpected for misc recording sample rate ({misc_sr}) to be higher than actual stimulus sample rate ({stim_sr})")
+    if misc_sr < stim_sr:
+        resampled_n = round(len(actual_envelope) * misc_sr / stim_sr)
+        actual_envelope = resample(actual_envelope, resampled_n)
+        stim_sr = misc_sr
 
     candidate_drifts = np.linspace(start=reference_drift - drift_range, stop=reference_drift + drift_range, num=grid_n)
     candidate_delays = np.linspace(start=reference_delay - delay_range, stop=reference_delay + delay_range, num=grid_n)
@@ -65,13 +65,13 @@ def fit_drift_delay(
     for drift in candidate_drifts:
         for delay in candidate_delays:
 
-            stretched_stimulus_envelope = _stretch_signal(stimulus_envelope, sample_rate=stimulus_sr, stretch=1 + drift, delay=delay)
+            stretched_stimulus_envelope = _stretch_signal(actual_envelope, sample_rate=stim_sr, stretch=1 + drift, delay=delay)
 
             # Score is correlation in overlapping region
-            overlap_length = min(len(stretched_stimulus_envelope), len(misc_envelope))
+            overlap_length = min(len(stretched_stimulus_envelope), len(recorded_envelope))
             score = np.corrcoef(
                 stretched_stimulus_envelope[:overlap_length],
-                misc_envelope[:overlap_length],
+                recorded_envelope[:overlap_length],
             )[0][1]
 
             if score > best_score:

--- a/kymata/preproc/sensor.py
+++ b/kymata/preproc/sensor.py
@@ -12,7 +12,7 @@ def fit_drift_delay(
         misc_sr: float,
         reference_drift: float = 0,   # seconds per second
         reference_delay: float = 0,   # seconds
-        drift_range: float = 0.0001,  # seconds per second
+        drift_range: float = 0.00001,  # seconds per second
         delay_range: float = 0.01,    # seconds
         grid_n: int = 101,
 ) -> tuple[float, float]:
@@ -89,13 +89,12 @@ def _hilbert_envolope(signal: NDArray) -> NDArray:
     return np.abs(hilbert(np.asarray(signal, dtype=float)))
 
 
-# TODO: Am I doing this in the right direction to fit with how it's done inside the gridsearch?
 def _stretch_signal(signal: NDArray, sample_rate: float, stretch: float, delay: float) -> NDArray:
     signal = np.asarray(signal, dtype=float)
     n_samples = len(signal)
 
     time_axis = np.arange(n_samples) / sample_rate
-    time_axis_stretched = (time_axis - delay) / stretch
+    time_axis_stretched = time_axis / stretch - delay
 
     interpolator = interp1d(time_axis, signal, kind="linear", bounds_error=False, fill_value=0.0, assume_sorted=True)
 

--- a/kymata/preproc/sensor.py
+++ b/kymata/preproc/sensor.py
@@ -10,10 +10,10 @@ def fit_drift_delay(
         stim_misc_recording: NDArray,
         stim_sr: float,
         misc_sr: float,
-        reference_drift: float = 0,
-        reference_delay: float = 0,
-        drift_range: float = 0.001,
-        delay_range: float = 0.01,
+        reference_drift: float = 0,   # seconds per second
+        reference_delay: float = 0,   # seconds
+        drift_range: float = 0.0001,  # seconds per second
+        delay_range: float = 0.01,    # seconds
         grid_n: int = 101,
 ) -> tuple[float, float]:
     """
@@ -27,7 +27,7 @@ def fit_drift_delay(
         misc_sr (float): sample rate of the misc channel (Hz)
         reference_drift (reference): a reference drift (s/s), usually taken from the config file
         reference_delay (reference): a reference delay (s), usually taken from the config file
-        drift_range (float): allowed values of actual drift are reference ± drift_range (seconds).
+        drift_range (float): allowed values of actual drift are reference ± drift_range (seconds per second).
         delay_range (float): allowed values of actual delay are reference ± delay_range (seconds).
         grid_n (int): Number of gridpoints to use in search.
 

--- a/tests/test_io_audio.py
+++ b/tests/test_io_audio.py
@@ -1,0 +1,116 @@
+# Tests written with some genai help
+
+import numpy as np
+from scipy.io import wavfile
+
+from kymata.io.audio import load_wav_as_floats
+
+
+def test_load_wav_as_floats_mono(tmp_path):
+    sr = 16000
+    pcm = np.array([0, 1000, -1000, 32767, -32768], dtype=np.int16)
+
+    path = tmp_path / "mono.wav"
+    wavfile.write(path, sr, pcm)
+
+    expected = pcm.astype(np.float32) / np.iinfo(np.int16).max
+
+    loaded, loaded_sr = load_wav_as_floats(path)
+
+    assert loaded.dtype == np.float32
+    assert loaded_sr == sr
+    np.testing.assert_allclose(loaded, expected, atol=1e-7)
+
+
+def test_load_wav_as_floats_stereo(tmp_path):
+    sr = 44100
+    pcm = np.array(
+        [[1, 2], [3, 4], [5, 6]],
+        dtype=np.int16,
+    )
+
+    path = tmp_path / "stereo.wav"
+    wavfile.write(path, sr, pcm)
+
+    expected = pcm.astype(np.float32) / np.iinfo(np.int16).max
+
+    loaded, loaded_sr = load_wav_as_floats(path)
+
+    assert loaded.dtype == np.float32
+    assert loaded_sr == sr
+    np.testing.assert_allclose(loaded, expected, atol=1e-7)
+
+
+def test_load_wav_as_floats_float32(tmp_path):
+    sr = 22050
+    audio = np.array([0.0, 0.5, -0.5], dtype=np.float32)
+
+    path = tmp_path / "float.wav"
+    wavfile.write(path, sr, audio)
+
+    loaded, loaded_sr = load_wav_as_floats(path)
+
+    assert loaded.dtype == np.float32
+    assert loaded_sr == sr
+    np.testing.assert_allclose(loaded, audio, atol=1e-7)
+
+
+def test_load_wav_as_floats_stereo_preserves_channels(tmp_path):
+    sr = 44100
+    pcm = np.array(
+        [[1000, -1000],
+         [2000, -2000],
+         [3000, -3000]],
+        dtype=np.int16,
+    )
+
+    path = tmp_path / "stereo.wav"
+    wavfile.write(path, sr, pcm)
+
+    loaded, loaded_sr = load_wav_as_floats(path)
+
+    expected = pcm.astype(np.float32) / np.iinfo(np.int16).max
+
+    assert loaded_sr == sr
+    assert loaded.dtype == np.float32
+    assert loaded.shape == (3, 2)
+    np.testing.assert_allclose(loaded, expected)
+
+
+def test_load_wav_as_floats_mix_to_mono(tmp_path):
+    sr = 44100
+    pcm = np.array(
+        [[1000, -1000],
+         [2000, 2000],
+         [-3000, 1000]],
+        dtype=np.int16,
+    )
+
+    path = tmp_path / "stereo.wav"
+    wavfile.write(path, sr, pcm)
+
+    loaded, loaded_sr = load_wav_as_floats(path, mix_to_mono=True)
+
+    expected = (
+        pcm.astype(np.float32) / np.iinfo(np.int16).max
+    ).mean(axis=1)
+
+    assert loaded_sr == sr
+    assert loaded.dtype == np.float32
+    assert loaded.shape == (3,)
+    np.testing.assert_allclose(loaded, expected)
+
+
+def test_load_wav_as_floats_mix_to_mono_is_noop_for_mono(tmp_path):
+    sr = 16000
+    pcm = np.array([1000, -1000, 2000], dtype=np.int16)
+
+    path = tmp_path / "mono.wav"
+    wavfile.write(path, sr, pcm)
+
+    loaded, _ = load_wav_as_floats(path, mix_to_mono=True)
+
+    expected = pcm.astype(np.float32) / np.iinfo(np.int16).max
+
+    assert loaded.shape == (3,)
+    np.testing.assert_allclose(loaded, expected)

--- a/tests/test_rudimentary.py
+++ b/tests/test_rudimentary.py
@@ -3,7 +3,7 @@ import pytest
 from kymata.entities.rudimentary import get_coerce
 
 
-def test_dict_get_coerce():
+def test_get_coerce():
     d = {"a": "123", "b": 4}
 
     assert get_coerce(d, key="a", default=0,  coerce=int) == 123
@@ -11,4 +11,4 @@ def test_dict_get_coerce():
     assert get_coerce(d, key="c", default=42, coerce=int) == 42
 
     with pytest.raises(ValueError):
-        get_coerce({"x": "abc"}, "x", 0, int)
+        get_coerce(d={"x": "abc"}, key="x", default=0, coerce=int)

--- a/tests/test_rudimentary.py
+++ b/tests/test_rudimentary.py
@@ -1,0 +1,14 @@
+import pytest
+
+from kymata.entities.rudimentary import get_coerce
+
+
+def test_dict_get_coerce():
+    d = {"a": "123", "b": 4}
+
+    assert get_coerce(d, key="a", default=0,  coerce=int) == 123
+    assert get_coerce(d, key="b", default="", coerce=str) == "4"
+    assert get_coerce(d, key="c", default=42, coerce=int) == 42
+
+    with pytest.raises(ValueError):
+        get_coerce({"x": "abc"}, "x", 0, int)


### PR DESCRIPTION
Uses @caiw's fit_drift_delay function to compare the config drift and delay estimates with the real thing.

- [x] Don't let the misc channel end up in the data used in gridsearch
- [x] use config not cili switch to turn checking on and off
- [x] Verify that drift and delay are being applied in the same direction here and in the gridsearch
- [x] Apply diffs in drift to the emeg data
- [x] Check if average diffs/drifts change and error
- [x] Check if drifts change and error

Aims to close #617