### PR TITLE
Function to create an anchored gradient colormap

### DIFF
--- a/kymata/plot/color.py
+++ b/kymata/plot/color.py
@@ -1,4 +1,4 @@
-from matplotlib.colors import to_rgb, to_hex
+from matplotlib.colors import to_rgb, to_hex, LinearSegmentedColormap
 from numpy import linspace
 
 transparent = (0, 0, 0, 0)
@@ -63,3 +63,28 @@ def constant_color_dict(transforms: list[str], color) -> dict[str, str]:
     The returned dictionary is compatible with color specifications for expression plots.
     """
     return gradient_color_dict(transforms, color, color)
+
+
+def anchored_gradient_colormap(name: str, anchor_values: list[float | int], colors: list):
+    """
+    Creates a colormap which is a stack of unequal-height gradients with segment endpoints at specific values.
+
+    Args:
+        name: The name of the colormap
+        anchor_values: List of anchor values for gradient segment boundaries (including first and last endpoints)
+        colors: Colours for each boundary point
+
+    Raises:
+        ValueError if `layer_anchors` and `colors` aren't of the same length.
+
+    Returns:
+        A LinearSegmentedColormap
+    """
+    if len(anchor_values) != len(colors):
+        raise ValueError("Specify one color exactly for each layer anchor")
+
+    # Convert layer anchors to value ranges
+    vmin, vmax = anchor_values[0], anchor_values[-1]
+    positions = [(v - vmin) / (vmax - vmin) for v in anchor_values]
+
+    return LinearSegmentedColormap.from_list(name, list(zip(positions, colors)))

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,12 +1,15 @@
+# Some tests written with genai
+
 from pathlib import Path
 
 import pytest
+from matplotlib.colors import to_rgba
 from numpy import array, array_equal
 
 from kymata.datasets.sample import delete_dataset
 from kymata.io.layouts import SensorLayout, MEGLayout, EEGLayout
 from kymata.io.nkg import load_expression_set
-from kymata.plot.color import gradient_color_dict
+from kymata.plot.color import gradient_color_dict, anchored_gradient_colormap
 from kymata.plot.expression import (
     _get_best_ylim,
     _MAJOR_TICK_SIZE,
@@ -508,3 +511,27 @@ def test_expression_set_plot_with_explicit_colour_for_hidden_transform():
         show_only=["d_IL1"],
         paired_axes=False,
     )
+
+
+def test_anchored_gradient_colormap_anchor_colours():
+    cmap = anchored_gradient_colormap(
+        "test",
+        [0, 1, 2],
+        ["blue", "white", "red"],
+    )
+
+    assert cmap(0.0) == pytest.approx(to_rgba("blue"), abs=1e-2)
+    assert cmap(0.5) == pytest.approx(to_rgba("white"), abs=1e-2)
+    assert cmap(1.0) == pytest.approx(to_rgba("red"), abs=1e-2)
+
+
+def test_anchored_gradient_colormap_uneven_spacing():
+    cmap = anchored_gradient_colormap(
+        "test",
+        [0, 1, 3],
+        ["blue", "white", "red"],
+    )
+
+    # White is at 1/3 of the range, so halfway to red is at 2/3.
+    expected = tuple((w + r) / 2 for w, r in zip(to_rgba("white"), to_rgba("red")))
+    assert cmap(2 / 3) == pytest.approx(expected, abs=1e-2)


### PR DESCRIPTION
Creates a new function `anchored_gradient_colormap` which creates a colormap which gradients between specified colour sequence, but with the anchor points of that gradient at unequal spacings along the colormap range.

(cherry picked from commit 7c58b483aac588a72b0019ec1624825744bf2796 - see #630 )